### PR TITLE
Bring skeleton

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,4 +45,38 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M7</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M7</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.8</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.organization>overpathz</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.organization>overpathz</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -32,6 +32,16 @@
             <artifactId>junit-jupiter-api</artifactId>
             <version>5.9.0</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.24</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/hoverla/bring/annotation/Autowired.java
+++ b/src/main/java/com/hoverla/bring/annotation/Autowired.java
@@ -1,0 +1,11 @@
+package com.hoverla.bring.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Autowired {
+}

--- a/src/main/java/com/hoverla/bring/annotation/Bean.java
+++ b/src/main/java/com/hoverla/bring/annotation/Bean.java
@@ -1,0 +1,12 @@
+package com.hoverla.bring.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Bean {
+    String value() default "";
+}

--- a/src/main/java/com/hoverla/bring/context/ApplicationContext.java
+++ b/src/main/java/com/hoverla/bring/context/ApplicationContext.java
@@ -1,0 +1,12 @@
+package com.hoverla.bring.context;
+
+import java.util.Map;
+
+public interface ApplicationContext {
+
+    <T> T getBean(Class<T> beanType);
+
+    <T> T getBean(String name, Class<T> beanType);
+
+    <T> Map<String, T> getAllBeans(Class<T> beanType);
+}

--- a/src/main/java/com/hoverla/bring/context/ApplicationContextImpl.java
+++ b/src/main/java/com/hoverla/bring/context/ApplicationContextImpl.java
@@ -1,0 +1,115 @@
+package com.hoverla.bring.context;
+
+import com.hoverla.bring.annotation.Autowired;
+import com.hoverla.bring.annotation.Bean;
+import com.hoverla.bring.exception.ApplicationContextInitializationException;
+import com.hoverla.bring.exception.NoSuchBeanException;
+import com.hoverla.bring.exception.NoUniqueBeanException;
+import org.reflections.Reflections;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toMap;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+public class ApplicationContextImpl implements ApplicationContext {
+    private final Map<String, Object> beans = new ConcurrentHashMap<>();
+
+    public ApplicationContextImpl(String... basePackages) {
+        Reflections beanScanner = new Reflections((Object[]) basePackages);
+        Set<Class<?>> beanClasses = beanScanner.getTypesAnnotatedWith(Bean.class, true);
+
+        if (beanClasses.isEmpty()) {
+            return;
+        }
+
+        try {
+            initBeans(beanClasses);
+            postProcess();
+        } catch (NoSuchMethodException | InvocationTargetException | InstantiationException
+                 | IllegalAccessException e) {
+            throw new ApplicationContextInitializationException(
+                format("ApplicationContext initialization has failed: %s", e.getMessage())
+            );
+        }
+    }
+
+    private void initBeans(Set<Class<?>> beanClasses) throws NoSuchMethodException, InvocationTargetException,
+        InstantiationException, IllegalAccessException {
+        for (Class<?> beanType: beanClasses) {
+            String beanName = resolveBeanName(beanType);
+            Object instance = beanType.getConstructor().newInstance();
+            beans.put(beanName, instance);
+        }
+    }
+
+    @SuppressWarnings("java:S3011")
+    private void postProcess() throws IllegalAccessException {
+        Collection<Object> beanInstances = beans.values();
+
+        for (Object beanInstance: beanInstances) {
+            for (Field field: beanInstance.getClass().getDeclaredFields()) {
+                if (field.isAnnotationPresent(Autowired.class)) {
+                    field.setAccessible(true);
+                    field.set(beanInstance, getBean(field.getType()));
+                }
+            }
+        }
+
+    }
+
+    private String resolveBeanName(Class<?> type) {
+        String beanName = type.getAnnotation(Bean.class).value();
+        return isNotBlank(beanName) ? beanName : resolveBeanName(type.getSimpleName());
+    }
+
+    private String resolveBeanName(String typeName) {
+        return typeName.substring(0, 1).toLowerCase() + typeName.substring(1);
+    }
+
+    @Override
+    public <T> T getBean(Class<T> beanType) {
+        Map<String, T> beanMap = getAllBeans(beanType);
+
+        if (beanMap.size() > 1) {
+            String matchingBeans = beanMap.entrySet().stream()
+                .map(e -> e.getKey() + ": " + e.getValue().getClass().getSimpleName())
+                .collect(joining(", "));
+            throw new NoUniqueBeanException(format("There is more than one bean matching the %s type: [%s]. " +
+                "Please specify a bean name!", beanType.getSimpleName(), matchingBeans));
+        }
+
+
+        return beanMap.entrySet().stream().findFirst()
+            .map(Entry::getValue)
+            .orElseThrow(() -> new NoSuchBeanException(
+                format("Bean with type %s not found", beanType.getSimpleName())
+            ));
+    }
+
+    @Override
+    public <T> T getBean(String name, Class<T> beanType) {
+        return Optional.ofNullable(beans.get(name))
+            .filter(potentialBean -> beanType.isAssignableFrom(potentialBean.getClass()))
+            .map(beanType::cast)
+            .orElseThrow(() -> new NoSuchBeanException(
+                format("Bean with name %s and type %s not found", name, beanType.getSimpleName())
+            ));
+    }
+
+    @Override
+    public <T> Map<String, T> getAllBeans(Class<T> beanType) {
+        return beans.entrySet().stream()
+            .filter(potentialBean -> beanType.isAssignableFrom(potentialBean.getValue().getClass()))
+            .collect(toMap(Entry::getKey, bean -> beanType.cast(bean.getValue())));
+    }
+}

--- a/src/main/java/com/hoverla/bring/exception/ApplicationContextInitializationException.java
+++ b/src/main/java/com/hoverla/bring/exception/ApplicationContextInitializationException.java
@@ -1,0 +1,8 @@
+package com.hoverla.bring.exception;
+
+public class ApplicationContextInitializationException extends RuntimeException {
+    public ApplicationContextInitializationException(String message) {
+        super(message);
+    }
+}
+

--- a/src/main/java/com/hoverla/bring/exception/DefaultConstructorNotFoundException.java
+++ b/src/main/java/com/hoverla/bring/exception/DefaultConstructorNotFoundException.java
@@ -1,0 +1,8 @@
+package com.hoverla.bring.exception;
+
+public class DefaultConstructorNotFoundException extends RuntimeException {
+
+    public DefaultConstructorNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/hoverla/bring/exception/NoSuchBeanException.java
+++ b/src/main/java/com/hoverla/bring/exception/NoSuchBeanException.java
@@ -1,0 +1,8 @@
+package com.hoverla.bring.exception;
+
+public class NoSuchBeanException extends RuntimeException {
+
+    public NoSuchBeanException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/hoverla/bring/exception/NoUniqueBeanException.java
+++ b/src/main/java/com/hoverla/bring/exception/NoUniqueBeanException.java
@@ -1,0 +1,8 @@
+package com.hoverla.bring.exception;
+
+public class NoUniqueBeanException extends RuntimeException {
+
+    public NoUniqueBeanException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/HelloTest.java
+++ b/src/test/java/HelloTest.java
@@ -1,9 +1,0 @@
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
-class HelloTest {
-    @Test
-    void test1() {
-        Assertions.assertFalse(true);
-    }
-}

--- a/src/test/java/com/hoverla/bring/context/ApplicationContextImplTest.java
+++ b/src/test/java/com/hoverla/bring/context/ApplicationContextImplTest.java
@@ -5,11 +5,13 @@ import com.hoverla.bring.context.fixtures.autowired.success.TestService;
 import com.hoverla.bring.context.fixtures.bean.ChildService;
 import com.hoverla.bring.context.fixtures.bean.NotABean;
 import com.hoverla.bring.context.fixtures.bean.ParentService;
+import com.hoverla.bring.context.fixtures.bean.success.A;
+import com.hoverla.bring.context.fixtures.bean.success.B;
 import com.hoverla.bring.context.fixtures.bean.success.ChildServiceBeanOne;
 import com.hoverla.bring.context.fixtures.bean.success.ChildServiceBeanTwo;
 import com.hoverla.bring.context.fixtures.bean.success.TestBeanWithName;
 import com.hoverla.bring.context.fixtures.bean.success.TestBeanWithoutName;
-import com.hoverla.bring.exception.ApplicationContextInitializationException;
+import com.hoverla.bring.exception.DefaultConstructorNotFoundException;
 import com.hoverla.bring.exception.NoSuchBeanException;
 import com.hoverla.bring.exception.NoUniqueBeanException;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,6 +48,9 @@ class ApplicationContextImplTest {
 
         TestBeanWithoutName beanWithoutName = applicationContext.getBean(TestBeanWithoutName.class);
         assertNotNull(beanWithoutName);
+
+        A aBean = applicationContext.getBean(A.class);
+        assertNotNull(aBean);
     }
 
     @Test
@@ -76,8 +81,12 @@ class ApplicationContextImplTest {
         TestBeanWithName beanWithName = applicationContext.getBean("BeanName", TestBeanWithName.class);
         assertNotNull(beanWithName);
 
-        TestBeanWithoutName beanWithoutName = applicationContext.getBean("testBeanWithoutName", TestBeanWithoutName.class);
+        TestBeanWithoutName beanWithoutName = applicationContext.getBean("testBeanWithoutName",
+            TestBeanWithoutName.class);
         assertNotNull(beanWithoutName);
+
+        B bBean = applicationContext.getBean("C", B.class);
+        assertNotNull(bBean);
     }
 
     @Test
@@ -138,6 +147,7 @@ class ApplicationContextImplTest {
         ApplicationContext autowiringContext =
             new ApplicationContextImpl("com.hoverla.bring.context.fixtures.autowired.success");
         AutowiredService autowiredService = autowiringContext.getBean(AutowiredService.class);
+        assertNotNull(autowiredService);
         TestService testService = autowiringContext.getBean(TestService.class);
         assertEquals("A,B,C", testService.getLetters());
     }
@@ -165,13 +175,11 @@ class ApplicationContextImplTest {
 
     @Test
     @Order(11)
-    @DisplayName("ApplicationContextInitializationException if no public constructor is found")
+    @DisplayName("DefaultConstructorNotFoundException if no default constructor is found")
     void applicationContextInitializationExceptionIfPackageDoesNotExist() {
-        ApplicationContextInitializationException e = assertThrows(ApplicationContextInitializationException.class, () ->
+        DefaultConstructorNotFoundException e = assertThrows(DefaultConstructorNotFoundException.class, () ->
             new ApplicationContextImpl("com.hoverla.bring.context.fixtures.initFailure"));
 
-        assertEquals("ApplicationContext initialization has failed: " +
-            "com.hoverla.bring.context.fixtures.initFailure.ClassWithPrivateConstructor.<init>()", e.getMessage());
-
+        assertEquals("Default constructor hasn't been found for ClassWithoutDefaultConstructor", e.getMessage());
     }
 }

--- a/src/test/java/com/hoverla/bring/context/ApplicationContextImplTest.java
+++ b/src/test/java/com/hoverla/bring/context/ApplicationContextImplTest.java
@@ -1,0 +1,177 @@
+package com.hoverla.bring.context;
+
+import com.hoverla.bring.context.fixtures.autowired.success.AutowiredService;
+import com.hoverla.bring.context.fixtures.autowired.success.TestService;
+import com.hoverla.bring.context.fixtures.bean.ChildService;
+import com.hoverla.bring.context.fixtures.bean.NotABean;
+import com.hoverla.bring.context.fixtures.bean.ParentService;
+import com.hoverla.bring.context.fixtures.bean.success.ChildServiceBeanOne;
+import com.hoverla.bring.context.fixtures.bean.success.ChildServiceBeanTwo;
+import com.hoverla.bring.context.fixtures.bean.success.TestBeanWithName;
+import com.hoverla.bring.context.fixtures.bean.success.TestBeanWithoutName;
+import com.hoverla.bring.exception.ApplicationContextInitializationException;
+import com.hoverla.bring.exception.NoSuchBeanException;
+import com.hoverla.bring.exception.NoUniqueBeanException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ApplicationContextImplTest {
+
+    private static final String CHILD_SERVICE_BEAN_ONE_NAME = "childServiceBeanOne";
+    private static final String CHILD_SERVICE_BEAN_TWO_NAME = "childServiceBean";
+
+    private ApplicationContext applicationContext;
+
+    @BeforeEach
+    void init() {
+        applicationContext = new ApplicationContextImpl("com.hoverla.bring.context.fixtures.bean");
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("Bean is successfully retrieved from the context by it's type")
+    void getBeanByClassReturnsCorrectBean() {
+        TestBeanWithName beanWithName = applicationContext.getBean(TestBeanWithName.class);
+        assertNotNull(beanWithName);
+
+        TestBeanWithoutName beanWithoutName = applicationContext.getBean(TestBeanWithoutName.class);
+        assertNotNull(beanWithoutName);
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("NoSuchBeanException is thrown if there is no such bean")
+    void getBeanByTypeWhenIfThereIsNoSuchBean() {
+        NoSuchBeanException noSuchBeanException =
+            assertThrows(NoSuchBeanException.class, () -> applicationContext.getBean(NotABean.class));
+        assertEquals("Bean with type NotABean not found", noSuchBeanException.getMessage());
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("NoUniqueBeanException is thrown if there are > 1 bean od the same type")
+    void getBeanByTypeIfThereIsADuplicateBean() {
+        NoUniqueBeanException noUniqueBeanException =
+            assertThrows(NoUniqueBeanException.class, () -> applicationContext.getBean(ParentService.class));
+
+        assertEquals("There is more than one bean matching the ParentService type: " +
+            "[childServiceBeanOne: ChildServiceBeanOne, childServiceBean: ChildServiceBeanTwo]. " +
+            "Please specify a bean name!", noUniqueBeanException.getMessage());
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("Bean is successfully retrieved from the context by it's name")
+    void getBeanByNameReturnsCorrectBean() {
+        TestBeanWithName beanWithName = applicationContext.getBean("BeanName", TestBeanWithName.class);
+        assertNotNull(beanWithName);
+
+        TestBeanWithoutName beanWithoutName = applicationContext.getBean("testBeanWithoutName", TestBeanWithoutName.class);
+        assertNotNull(beanWithoutName);
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("NoSuchBeanException is thrown if there is no such bean with a name")
+    void getBeanByNameIfThereIsNoSuchBean() {
+        NoSuchBeanException noSuchBeanException =
+            assertThrows(NoSuchBeanException.class, () -> applicationContext.getBean("Ho", TestBeanWithName.class));
+        assertEquals("Bean with name Ho and type TestBeanWithName not found", noSuchBeanException.getMessage());
+
+        noSuchBeanException =
+            assertThrows(NoSuchBeanException.class, () -> applicationContext.getBean("ver", TestBeanWithoutName.class));
+        assertEquals("Bean with name ver and type TestBeanWithoutName not found", noSuchBeanException.getMessage());
+
+        noSuchBeanException =
+            assertThrows(NoSuchBeanException.class, () -> applicationContext.getBean("la", NotABean.class));
+        assertEquals("Bean with name la and type NotABean not found", noSuchBeanException.getMessage());
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("Bean is successfully retrieved by it's name and superclass")
+    void getBeanByNameAndSuperClassReturnsCorrectBean() {
+        ChildServiceBeanOne childServiceBeanOne = (ChildServiceBeanOne) applicationContext
+            .getBean(CHILD_SERVICE_BEAN_ONE_NAME, ParentService.class);
+        assertNotNull(childServiceBeanOne);
+
+        ChildServiceBeanTwo childServiceBeanTwo = (ChildServiceBeanTwo) applicationContext
+            .getBean(CHILD_SERVICE_BEAN_TWO_NAME, ParentService.class);
+        assertNotNull(childServiceBeanTwo);
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("Get all beans by type returns the matching objects")
+    void getAllBeansReturnsCorrectMap() {
+        Map<String, ParentService> services = applicationContext.getAllBeans(ParentService.class);
+
+        assertEquals(2, services.size());
+
+        assertTrue(services.containsKey(CHILD_SERVICE_BEAN_ONE_NAME));
+        assertTrue(services.containsKey(CHILD_SERVICE_BEAN_TWO_NAME));
+
+        ChildServiceBeanOne autowiredService = (ChildServiceBeanOne) services.get(CHILD_SERVICE_BEAN_ONE_NAME);
+        ChildServiceBeanTwo testService = (ChildServiceBeanTwo) services.get(CHILD_SERVICE_BEAN_TWO_NAME);
+        assertNotNull(autowiredService);
+        assertNotNull(testService);
+
+        //ChildService is a subclass of ParentService, but it is not a bean
+        assertTrue(ParentService.class.isAssignableFrom(ChildService.class));
+        assertFalse(services.containsKey("childService"));
+    }
+
+    @Test
+    @Order(8)
+    @DisplayName("Autowiring has been successful")
+    void autowiringFieldIsSetCorrectly() {
+        ApplicationContext autowiringContext =
+            new ApplicationContextImpl("com.hoverla.bring.context.fixtures.autowired.success");
+        AutowiredService autowiredService = autowiringContext.getBean(AutowiredService.class);
+        TestService testService = autowiringContext.getBean(TestService.class);
+        assertEquals("A,B,C", testService.getLetters());
+    }
+
+    @Test
+    @Order(9)
+    @DisplayName("NoSuchBeanException is thrown if there is no bean which can be autowired")
+    void autowiringFieldIfThereIsNoSuchBean() {
+        NoSuchBeanException noSuchBeanException = assertThrows(NoSuchBeanException.class, () ->
+            new ApplicationContextImpl("com.hoverla.bring.context.fixtures.autowired.nosuchbean"));
+
+        assertEquals("Bean with type NotABeanService not found", noSuchBeanException.getMessage());
+    }
+
+    @Test
+    @Order(10)
+    @DisplayName("NoUniqueBeanException is thrown if there are > 1 bean of the same type for autowiring")
+    void autowiringFieldIThereIsNoUniqueBean() {
+        NoUniqueBeanException noUniqueBeanException = assertThrows(NoUniqueBeanException.class, () ->
+            new ApplicationContextImpl("com.hoverla.bring.context.fixtures.autowired.nouniquebean"));
+        assertEquals("There is more than one bean matching the JustAnotherService type: " +
+            "[childServiceOne: ChildServiceOne, childServiceTwo: ChildServiceTwo]. " +
+            "Please specify a bean name!", noUniqueBeanException.getMessage());
+    }
+
+    @Test
+    @Order(11)
+    @DisplayName("ApplicationContextInitializationException if no public constructor is found")
+    void applicationContextInitializationExceptionIfPackageDoesNotExist() {
+        ApplicationContextInitializationException e = assertThrows(ApplicationContextInitializationException.class, () ->
+            new ApplicationContextImpl("com.hoverla.bring.context.fixtures.initFailure"));
+
+        assertEquals("ApplicationContext initialization has failed: " +
+            "com.hoverla.bring.context.fixtures.initFailure.ClassWithPrivateConstructor.<init>()", e.getMessage());
+
+    }
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/autowired/nosuchbean/NoSuchBeanService.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/autowired/nosuchbean/NoSuchBeanService.java
@@ -1,0 +1,11 @@
+package com.hoverla.bring.context.fixtures.autowired.nosuchbean;
+
+import com.hoverla.bring.annotation.Autowired;
+import com.hoverla.bring.annotation.Bean;
+
+@Bean
+public class NoSuchBeanService {
+
+    @Autowired
+    NotABeanService notABeanService;
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/autowired/nosuchbean/NotABeanService.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/autowired/nosuchbean/NotABeanService.java
@@ -1,0 +1,4 @@
+package com.hoverla.bring.context.fixtures.autowired.nosuchbean;
+
+public class NotABeanService {
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/autowired/nouniquebean/ChildServiceOne.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/autowired/nouniquebean/ChildServiceOne.java
@@ -1,0 +1,7 @@
+package com.hoverla.bring.context.fixtures.autowired.nouniquebean;
+
+import com.hoverla.bring.annotation.Bean;
+
+@Bean
+public class ChildServiceOne extends JustAnotherService{
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/autowired/nouniquebean/ChildServiceTwo.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/autowired/nouniquebean/ChildServiceTwo.java
@@ -1,0 +1,7 @@
+package com.hoverla.bring.context.fixtures.autowired.nouniquebean;
+
+import com.hoverla.bring.annotation.Bean;
+
+@Bean
+public class ChildServiceTwo extends JustAnotherService{
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/autowired/nouniquebean/JustAnotherService.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/autowired/nouniquebean/JustAnotherService.java
@@ -1,0 +1,4 @@
+package com.hoverla.bring.context.fixtures.autowired.nouniquebean;
+
+public class JustAnotherService {
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/autowired/nouniquebean/NoUniqueBeanService.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/autowired/nouniquebean/NoUniqueBeanService.java
@@ -1,0 +1,11 @@
+package com.hoverla.bring.context.fixtures.autowired.nouniquebean;
+
+import com.hoverla.bring.annotation.Autowired;
+import com.hoverla.bring.annotation.Bean;
+
+@Bean
+public class NoUniqueBeanService {
+
+    @Autowired
+    JustAnotherService justAnotherService;
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/autowired/success/AutowiredService.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/autowired/success/AutowiredService.java
@@ -1,0 +1,13 @@
+package com.hoverla.bring.context.fixtures.autowired.success;
+
+import com.hoverla.bring.annotation.Bean;
+
+import java.util.List;
+
+@Bean
+public class AutowiredService extends AutowiringParentService {
+
+    public List<String> getLettersList() {
+        return List.of("A", "B", "C");
+    }
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/autowired/success/AutowiringParentService.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/autowired/success/AutowiringParentService.java
@@ -1,0 +1,4 @@
+package com.hoverla.bring.context.fixtures.autowired.success;
+
+public class AutowiringParentService {
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/autowired/success/TestService.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/autowired/success/TestService.java
@@ -1,0 +1,14 @@
+package com.hoverla.bring.context.fixtures.autowired.success;
+
+import com.hoverla.bring.annotation.Autowired;
+import com.hoverla.bring.annotation.Bean;
+
+@Bean("NotDefaultName")
+public class TestService extends AutowiringParentService {
+    @Autowired
+    private AutowiredService autowiredService;
+
+    public String getLetters() {
+        return String.join(",", autowiredService.getLettersList());
+    }
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/bean/ChildService.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/bean/ChildService.java
@@ -1,0 +1,4 @@
+package com.hoverla.bring.context.fixtures.bean;
+
+public class ChildService extends ParentService {
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/bean/NotABean.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/bean/NotABean.java
@@ -1,0 +1,4 @@
+package com.hoverla.bring.context.fixtures.bean;
+
+public class NotABean {
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/bean/ParentService.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/bean/ParentService.java
@@ -1,0 +1,4 @@
+package com.hoverla.bring.context.fixtures.bean;
+
+public class ParentService {
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/bean/success/A.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/bean/success/A.java
@@ -1,0 +1,7 @@
+package com.hoverla.bring.context.fixtures.bean.success;
+
+import com.hoverla.bring.annotation.Bean;
+
+@Bean
+public class A {
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/bean/success/B.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/bean/success/B.java
@@ -1,0 +1,7 @@
+package com.hoverla.bring.context.fixtures.bean.success;
+
+import com.hoverla.bring.annotation.Bean;
+
+@Bean("C")
+public class B {
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/bean/success/ChildServiceBeanOne.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/bean/success/ChildServiceBeanOne.java
@@ -1,0 +1,8 @@
+package com.hoverla.bring.context.fixtures.bean.success;
+
+import com.hoverla.bring.annotation.Bean;
+import com.hoverla.bring.context.fixtures.bean.ParentService;
+
+@Bean
+public class ChildServiceBeanOne extends ParentService {
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/bean/success/ChildServiceBeanTwo.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/bean/success/ChildServiceBeanTwo.java
@@ -1,0 +1,8 @@
+package com.hoverla.bring.context.fixtures.bean.success;
+
+import com.hoverla.bring.annotation.Bean;
+import com.hoverla.bring.context.fixtures.bean.ParentService;
+
+@Bean("childServiceBean")
+public class ChildServiceBeanTwo extends ParentService {
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/bean/success/TestBeanWithName.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/bean/success/TestBeanWithName.java
@@ -1,0 +1,7 @@
+package com.hoverla.bring.context.fixtures.bean.success;
+
+import com.hoverla.bring.annotation.Bean;
+
+@Bean("BeanName")
+public class TestBeanWithName {
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/bean/success/TestBeanWithoutName.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/bean/success/TestBeanWithoutName.java
@@ -1,0 +1,7 @@
+package com.hoverla.bring.context.fixtures.bean.success;
+
+import com.hoverla.bring.annotation.Bean;
+
+@Bean
+public class TestBeanWithoutName {
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/initFailure/ClassWithPrivateConstructor.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/initFailure/ClassWithPrivateConstructor.java
@@ -1,0 +1,11 @@
+package com.hoverla.bring.context.fixtures.initFailure;
+
+import com.hoverla.bring.annotation.Bean;
+
+@Bean
+public class ClassWithPrivateConstructor {
+
+    private ClassWithPrivateConstructor() {
+
+    }
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/initFailure/ClassWithoutDefaultConstructor.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/initFailure/ClassWithoutDefaultConstructor.java
@@ -3,9 +3,8 @@ package com.hoverla.bring.context.fixtures.initFailure;
 import com.hoverla.bring.annotation.Bean;
 
 @Bean
-public class ClassWithPrivateConstructor {
-
-    private ClassWithPrivateConstructor() {
+public class ClassWithoutDefaultConstructor {
+    public ClassWithoutDefaultConstructor(String s) {
 
     }
 }


### PR DESCRIPTION
This PR adds the `ApplicationContext` to the app with the support of basic annotations like `@Bean` and `@Autowired`. `ApplicationContext` tests are also added.