### PR TITLE
add @Configuration and BeanDefinition support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,20 @@
             <version>3.3.0</version>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>5.9.0</version>
             <scope>test</scope>
         </dependency>
@@ -50,6 +62,12 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
             <version>1.2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.24.2</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/java/com/hoverla/bring/annotation/Autowired.java
+++ b/src/main/java/com/hoverla/bring/annotation/Autowired.java
@@ -3,11 +3,12 @@ package com.hoverla.bring.annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Retention(RUNTIME)
-@Target({FIELD, METHOD})
+@Target({FIELD, METHOD, CONSTRUCTOR})
 public @interface Autowired {
 }

--- a/src/main/java/com/hoverla/bring/annotation/Configuration.java
+++ b/src/main/java/com/hoverla/bring/annotation/Configuration.java
@@ -3,12 +3,10 @@ package com.hoverla.bring.annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+@Target(TYPE)
 @Retention(RUNTIME)
-@Target({TYPE, METHOD})
-public @interface Bean {
-    String value() default "";
+public @interface Configuration {
 }

--- a/src/main/java/com/hoverla/bring/context/bean/definition/AbstractBeanDefinition.java
+++ b/src/main/java/com/hoverla/bring/context/bean/definition/AbstractBeanDefinition.java
@@ -1,0 +1,38 @@
+package com.hoverla.bring.context.bean.definition;
+
+import com.hoverla.bring.context.bean.dependency.BeanDependency;
+
+import java.util.Map;
+import java.util.Objects;
+
+public abstract class AbstractBeanDefinition implements BeanDefinition{
+    protected Object instance;
+    protected String name;
+    protected Class<?> type;
+    protected Map<String, BeanDependency> dependencies;
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public Class<?> type() {
+        return type;
+    }
+
+    @Override
+    public Map<String, BeanDependency> dependencies() {
+        return dependencies;
+    }
+
+    @Override
+    public boolean isInstantiated() {
+        return Objects.nonNull(instance);
+    }
+
+    @Override
+    public Object getInstance() {
+        return instance;
+    }
+}

--- a/src/main/java/com/hoverla/bring/context/bean/definition/BeanDefinition.java
+++ b/src/main/java/com/hoverla/bring/context/bean/definition/BeanDefinition.java
@@ -1,0 +1,21 @@
+package com.hoverla.bring.context.bean.definition;
+
+import com.hoverla.bring.context.bean.dependency.BeanDependency;
+
+import java.util.Map;
+
+public interface BeanDefinition {
+    String name();
+
+    Class<?> type();
+
+    Map<String, BeanDependency> dependencies();
+
+    boolean isInstantiated();
+
+    void instantiate(BeanDefinition... dependencies);
+
+    Object getInstance();
+
+    boolean isPrimary();
+}

--- a/src/main/java/com/hoverla/bring/context/bean/definition/BeanDefinitionContainer.java
+++ b/src/main/java/com/hoverla/bring/context/bean/definition/BeanDefinitionContainer.java
@@ -1,0 +1,43 @@
+package com.hoverla.bring.context.bean.definition;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.toConcurrentMap;
+import static java.util.stream.Collectors.toList;
+
+public class BeanDefinitionContainer {
+    private final Map<String, BeanDefinition> beanDefinitions;
+
+    public BeanDefinitionContainer(List<BeanDefinition> beanDefinitions) {
+        this.beanDefinitions = beanDefinitions
+            .stream()
+            .collect(toConcurrentMap(BeanDefinition::name, Function.identity()));
+    }
+
+    public Optional<BeanDefinition> getBeanDefinitionByName(String name) {
+        return Optional.ofNullable(beanDefinitions.get(name));
+    }
+
+    public List<BeanDefinition> getBeansAssignableFromType(Class<?> type) {
+        return beanDefinitions.values()
+            .stream()
+            .filter(bd -> type.isAssignableFrom(bd.type()))
+            .collect(toList());
+    }
+
+    public List<BeanDefinition> getBeansWithExactType(Class<?> type) {
+        return beanDefinitions.values()
+            .stream()
+            .filter(bd -> type.equals(bd.type()))
+            .collect(toList());
+    }
+
+    public Collection<BeanDefinition> getBeanDefinitions() {
+        return beanDefinitions.values();
+    }
+
+}

--- a/src/main/java/com/hoverla/bring/context/bean/definition/BeanDefinitionMapper.java
+++ b/src/main/java/com/hoverla/bring/context/bean/definition/BeanDefinitionMapper.java
@@ -1,0 +1,16 @@
+package com.hoverla.bring.context.bean.definition;
+
+import java.lang.reflect.Method;
+
+public class BeanDefinitionMapper {
+
+    public BeanDefinition mapToBeanDefinition(Class<?> beanClass) {
+        return new DefaultBeanDefinition(beanClass);
+    }
+
+
+    public BeanDefinition mapToBeanDefinition(Object configuration, Method beanMethod) {
+        return new ConfigurationBeanDefinition(configuration, beanMethod);
+    }
+
+}

--- a/src/main/java/com/hoverla/bring/context/bean/definition/ConfigurationBeanDefinition.java
+++ b/src/main/java/com/hoverla/bring/context/bean/definition/ConfigurationBeanDefinition.java
@@ -18,13 +18,9 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
-public class ConfigurationBeanDefinition implements BeanDefinition {
-    private Object instance;
-    private final String name;
+public class ConfigurationBeanDefinition extends AbstractBeanDefinition {
     private final Object configInstance;
     private final Method beanMethod;
-    private final Class<?> type;
-    private final Map<String, BeanDependency> dependencies;
 
     public ConfigurationBeanDefinition(Object configInstance, Method beanMethod) {
         Objects.requireNonNull(configInstance, "Configuration class instance can't be null");
@@ -38,36 +34,11 @@ public class ConfigurationBeanDefinition implements BeanDefinition {
     }
 
     @Override
-    public String name() {
-        return name;
-    }
-
-    @Override
-    public Class<?> type() {
-        return type;
-    }
-
-    @Override
-    public Map<String, BeanDependency> dependencies() {
-        return dependencies;
-    }
-
-    @Override
-    public boolean isInstantiated() {
-        return Objects.nonNull(instance);
-    }
-
-    @Override
     public void instantiate(BeanDefinition... dependencies) {
         if (!isInstantiated()) {
             List<BeanDefinition> dependencyList = new ArrayList<>(List.of(dependencies));
             instance = createInstance(dependencyList);
         }
-    }
-
-    @Override
-    public Object getInstance() {
-        return instance;
     }
 
     @Override

--- a/src/main/java/com/hoverla/bring/context/bean/definition/ConfigurationBeanDefinition.java
+++ b/src/main/java/com/hoverla/bring/context/bean/definition/ConfigurationBeanDefinition.java
@@ -1,0 +1,109 @@
+package com.hoverla.bring.context.bean.definition;
+
+import com.hoverla.bring.annotation.Bean;
+import com.hoverla.bring.annotation.Primary;
+import com.hoverla.bring.context.bean.dependency.BeanDependency;
+import com.hoverla.bring.context.util.ResolveDependenciesUtil;
+import com.hoverla.bring.exception.BeanInstanceCreationException;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toMap;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+public class ConfigurationBeanDefinition implements BeanDefinition {
+    private Object instance;
+    private final String name;
+    private final Object configInstance;
+    private final Method beanMethod;
+    private final Class<?> type;
+    private final Map<String, BeanDependency> dependencies;
+
+    public ConfigurationBeanDefinition(Object configInstance, Method beanMethod) {
+        Objects.requireNonNull(configInstance, "Configuration class instance can't be null");
+        Objects.requireNonNull(beanMethod, "Configuration bean method can't be null");
+
+        this.configInstance = configInstance;
+        this.beanMethod = beanMethod;
+        this.name = resolveName(beanMethod);
+        this.type = getType(beanMethod);
+        this.dependencies = resolveDependencies(beanMethod);
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public Class<?> type() {
+        return type;
+    }
+
+    @Override
+    public Map<String, BeanDependency> dependencies() {
+        return dependencies;
+    }
+
+    @Override
+    public boolean isInstantiated() {
+        return Objects.nonNull(instance);
+    }
+
+    @Override
+    public void instantiate(BeanDefinition... dependencies) {
+        if (!isInstantiated()) {
+            List<BeanDefinition> dependencyList = new ArrayList<>(List.of(dependencies));
+            instance = createInstance(dependencyList);
+        }
+    }
+
+    @Override
+    public Object getInstance() {
+        return instance;
+    }
+
+    @Override
+    public boolean isPrimary() {
+        return beanMethod.isAnnotationPresent(Primary.class);
+    }
+
+    private String resolveName(Method beanMethod) {
+        Bean beanAnnotation = beanMethod.getAnnotation(Bean.class);
+        String beanName = beanAnnotation.value();
+        if (isBlank(beanName)) {
+            return beanMethod.getName();
+        }
+        return beanName;
+    }
+
+    private Class<?> getType(Method beanMethod) {
+        return beanMethod.getReturnType();
+    }
+
+    private Map<String, BeanDependency> resolveDependencies(Method beanMethod) {
+        return Stream.of(beanMethod.getParameters())
+            .map(BeanDependency::fromParameter)
+            .collect(toMap(BeanDependency::getName, Function.identity()));
+    }
+
+    private Object createInstance(List<BeanDefinition> dependencies) {
+        try {
+            Parameter[] parameters = beanMethod.getParameters();
+            Object[] constructorArguments = new Object[parameters.length];
+
+            List<Parameter> params = new ArrayList<>(List.of(parameters));
+            ResolveDependenciesUtil.resolveDependencies(dependencies, params, constructorArguments, name);
+            return beanMethod.invoke(configInstance, constructorArguments);
+        } catch (Exception e) {
+            throw new BeanInstanceCreationException(String.format("Bean with name '%s' can't be instantiated", name), e);
+        }
+    }
+}

--- a/src/main/java/com/hoverla/bring/context/bean/definition/DefaultBeanDefinition.java
+++ b/src/main/java/com/hoverla/bring/context/bean/definition/DefaultBeanDefinition.java
@@ -1,0 +1,233 @@
+package com.hoverla.bring.context.bean.definition;
+
+import com.hoverla.bring.annotation.Autowired;
+import com.hoverla.bring.annotation.Bean;
+import com.hoverla.bring.annotation.Primary;
+import com.hoverla.bring.context.bean.dependency.BeanDependency;
+import com.hoverla.bring.context.util.ResolveDependenciesUtil;
+import com.hoverla.bring.exception.BeanDependencyInjectionException;
+import com.hoverla.bring.exception.BeanInstanceCreationException;
+import lombok.SneakyThrows;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyMap;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+import static org.apache.commons.lang3.ArrayUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+public class DefaultBeanDefinition implements BeanDefinition {
+    private Object instance;
+    private final String name;
+    private Constructor<?> constructor;
+    private List<Field> autowiredFields;
+    private final Class<?> type;
+    private final Map<String, BeanDependency> dependencies;
+
+    public DefaultBeanDefinition(Class<?> beanClass) {
+        Objects.requireNonNull(beanClass, "Bean class cannot be null");
+        this.type = beanClass;
+        this.name = resolveName(beanClass);
+        this.dependencies = resolveDependencies(beanClass);
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public Class<?> type() {
+        return type;
+    }
+
+    @Override
+    public Map<String, BeanDependency> dependencies() {
+        return dependencies;
+    }
+
+    @Override
+    public boolean isInstantiated() {
+        return Objects.nonNull(instance);
+    }
+
+    @Override
+    public void instantiate(BeanDefinition... dependencies) {
+        if (!isInstantiated()) {
+            List<BeanDefinition> dependencyList = new ArrayList<>(List.of(dependencies));
+            instance = createInstance(dependencyList);
+        }
+    }
+
+    @Override
+    public Object getInstance() {
+        return instance;
+    }
+
+    @Override
+    public boolean isPrimary() {
+        return type.isAnnotationPresent(Primary.class);
+    }
+
+    private String resolveName(Class<?> beanClass) {
+        Bean beanAnnotation = beanClass.getAnnotation(Bean.class);
+        String beanName = beanAnnotation.value();
+        if (isBlank(beanName)) {
+            return beanClass.getName();
+        }
+        return beanName;
+    }
+
+    private Map<String, BeanDependency> resolveDependencies(Class<?> beanClass) {
+        Map<String, BeanDependency> allDependencies = new HashMap<>();
+        allDependencies.putAll(resolveConstructorDependencies(beanClass));
+        allDependencies.putAll(resolveFieldDependencies(beanClass));
+
+        return allDependencies;
+    }
+
+    private Map<String, BeanDependency> resolveConstructorDependencies(Class<?> beanClass) {
+        Constructor<?>[] beanConstructors = beanClass.getConstructors();
+
+        return Stream.of(beanConstructors)
+            .filter(injectedConstructor -> injectedConstructor.isAnnotationPresent(Autowired.class))
+            .findFirst()
+            .map(this::resolveConstructorDependencies)
+            .orElseGet(() -> resolveConstructorDependencies(beanConstructors[0]));
+    }
+
+    private Map<String, BeanDependency> resolveConstructorDependencies(Constructor<?> beanConstructor) {
+        this.constructor = beanConstructor;
+
+        Parameter[] constructorParams = constructor.getParameters();
+        if (isEmpty(constructorParams)) {
+            return emptyMap();
+        }
+        return Stream.of(constructorParams)
+            .map(BeanDependency::fromParameter)
+            .collect(toMap(BeanDependency::getName, identity()));
+    }
+
+    private Map<String, BeanDependency> resolveFieldDependencies(Class<?> beanClass) {
+        List<Field> classFields = new ArrayList<>(List.of(beanClass.getDeclaredFields()));
+        this.autowiredFields = getAutowiredElements(classFields);
+
+        if (autowiredFields.isEmpty()) {
+            return emptyMap();
+        }
+        return autowiredFields.stream()
+            .map(BeanDependency::fromField)
+            .collect(toMap(BeanDependency::getName, identity()));
+    }
+
+    private <T extends AnnotatedElement> List<T> getAutowiredElements(List<T> elements) {
+        return elements.stream()
+            .filter(e -> e.isAnnotationPresent(Autowired.class))
+            .collect(Collectors.toList());
+    }
+
+    private Object createInstance(List<BeanDefinition> dependencies) {
+        try {
+            Objects.requireNonNull(dependencies);
+            this.instance = doCreateInstance(dependencies);
+            return instance;
+        } catch (Exception e) {
+            throw new BeanInstanceCreationException(String.format("Bean with name '%s' can't be instantiated", name), e);
+        }
+    }
+
+    @SneakyThrows
+    private Object doCreateInstance(List<BeanDefinition> dependencies) {
+        Object beanInstance = createInstanceUsingConstructor(dependencies);
+
+        if (!dependencies.isEmpty()) {
+            doFieldAutowiring(beanInstance, dependencies);
+        }
+        return beanInstance;
+    }
+
+    @SneakyThrows
+    private Object createInstanceUsingConstructor(List<BeanDefinition> dependencies) {
+        if (constructor.getParameterCount() == 0) {
+            return constructor.newInstance();
+        }
+        List<Parameter> parameters = new ArrayList<>(List.of(constructor.getParameters()));
+        Object[] constructorArgs = new Object[parameters.size()];
+
+        ResolveDependenciesUtil.resolveDependencies(dependencies, parameters, constructorArgs, name);
+        return constructor.newInstance(constructorArgs);
+    }
+
+    private void doFieldAutowiring(Object beanInstance, List<BeanDefinition> dependencies) {
+        autowiredFields
+            .stream()
+            .sorted(this::subclassesFirst)
+            .forEach(field -> autowireField(beanInstance, field, dependencies));
+
+        verifyFieldAutowiring(beanInstance);
+    }
+
+    private int subclassesFirst(Field field,
+                                       Field anotherField) {
+        Class<?> fieldType = field.getType();
+        Class<?> anotherFieldType = anotherField.getType();
+        if (fieldType.isAssignableFrom(anotherFieldType)) {
+            return 1;
+        }
+        return -1;
+    }
+
+    private void autowireField(Object beanInstance, Field targetField, List<BeanDefinition> dependencies) {
+        dependencies.stream()
+            .filter(dependency -> fieldMatch(targetField, dependency))
+            .findAny()
+            .ifPresent(dependency -> {
+                setFieldValue(targetField, beanInstance, dependency);
+                dependencies.remove(dependency);
+            });
+    }
+
+    @SuppressWarnings("java:S2589")
+    private boolean fieldMatch(Field field, BeanDefinition dependencyToMatch) {
+        Class<?> fieldType = field.getType();
+        return fieldType.isAssignableFrom(dependencyToMatch.type());
+    }
+
+    private void verifyFieldAutowiring(Object beanInstance) {
+        List<String> unresolvedFieldNames = autowiredFields.stream()
+            .filter(field -> injectionFailedForField(field, beanInstance))
+            .map(Field::getName)
+            .collect(Collectors.toList());
+        if (!unresolvedFieldNames.isEmpty()) {
+            throw new BeanDependencyInjectionException(String.format(
+                "Field injection failed for bean instance of type %s. Unresolved fields: %s",
+                beanInstance.getClass().getName(), unresolvedFieldNames)
+            );
+        }
+    }
+
+    @SneakyThrows
+    @SuppressWarnings("java:S3011")
+    private void setFieldValue(Field field, Object beanInstance, BeanDefinition dependency) {
+        field.setAccessible(true);
+        field.set(beanInstance, dependency.getInstance());
+    }
+
+    @SneakyThrows
+    @SuppressWarnings("java:S3011")
+    private boolean injectionFailedForField(Field targetField, Object beanInstance) {
+        targetField.setAccessible(true);
+        return targetField.get(beanInstance) == null;
+    }
+}

--- a/src/main/java/com/hoverla/bring/context/bean/definition/DefaultBeanDefinition.java
+++ b/src/main/java/com/hoverla/bring/context/bean/definition/DefaultBeanDefinition.java
@@ -27,13 +27,9 @@ import static java.util.stream.Collectors.toMap;
 import static org.apache.commons.lang3.ArrayUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
-public class DefaultBeanDefinition implements BeanDefinition {
-    private Object instance;
-    private final String name;
+public class DefaultBeanDefinition extends AbstractBeanDefinition {
     private Constructor<?> constructor;
     private List<Field> autowiredFields;
-    private final Class<?> type;
-    private final Map<String, BeanDependency> dependencies;
 
     public DefaultBeanDefinition(Class<?> beanClass) {
         Objects.requireNonNull(beanClass, "Bean class cannot be null");
@@ -43,36 +39,11 @@ public class DefaultBeanDefinition implements BeanDefinition {
     }
 
     @Override
-    public String name() {
-        return name;
-    }
-
-    @Override
-    public Class<?> type() {
-        return type;
-    }
-
-    @Override
-    public Map<String, BeanDependency> dependencies() {
-        return dependencies;
-    }
-
-    @Override
-    public boolean isInstantiated() {
-        return Objects.nonNull(instance);
-    }
-
-    @Override
     public void instantiate(BeanDefinition... dependencies) {
         if (!isInstantiated()) {
             List<BeanDefinition> dependencyList = new ArrayList<>(List.of(dependencies));
             instance = createInstance(dependencyList);
         }
-    }
-
-    @Override
-    public Object getInstance() {
-        return instance;
     }
 
     @Override

--- a/src/main/java/com/hoverla/bring/context/bean/dependency/BeanDependency.java
+++ b/src/main/java/com/hoverla/bring/context/bean/dependency/BeanDependency.java
@@ -1,0 +1,32 @@
+package com.hoverla.bring.context.bean.dependency;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Parameter;
+
+@Getter
+@EqualsAndHashCode(of = {"name"})
+@AllArgsConstructor
+public class BeanDependency {
+
+    @Setter
+    private String name;
+
+    private Class<?> type;
+
+    public static BeanDependency fromParameter(Parameter parameter) {
+        Class<?> type = parameter.getType();
+        String name = type.getName();
+        return new BeanDependency(name, type);
+    }
+
+    public static BeanDependency fromField(Field field) {
+        Class<?> type = field.getType();
+        String name = type.getName();
+        return new BeanDependency(name, type);
+    }
+}

--- a/src/main/java/com/hoverla/bring/context/bean/dependency/BeanDependencyNameResolver.java
+++ b/src/main/java/com/hoverla/bring/context/bean/dependency/BeanDependencyNameResolver.java
@@ -1,0 +1,129 @@
+package com.hoverla.bring.context.bean.dependency;
+
+import com.hoverla.bring.context.bean.definition.BeanDefinition;
+import com.hoverla.bring.context.bean.definition.BeanDefinitionContainer;
+import com.hoverla.bring.exception.BeanInstanceCreationException;
+import com.hoverla.bring.exception.MissingDependencyException;
+import com.hoverla.bring.exception.NoUniqueBeanException;
+import org.apache.commons.lang3.tuple.Pair;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static com.hoverla.bring.exception.MissingDependencyException.*;
+import static com.hoverla.bring.exception.NoUniqueBeanException.NO_UNIQUE_BEAN_EXCEPTION;
+import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
+
+public class BeanDependencyNameResolver {
+    public void resolveDependencyNames(BeanDefinitionContainer container) {
+        for (BeanDefinition beanDefinition : container.getBeanDefinitions()) {
+            Map<String, BeanDependency> beanDependencies = beanDefinition.dependencies();
+
+            if (beanDependencies.isEmpty()) {
+                continue;
+            }
+
+            List<Pair<String, String>> oldToNewNames = beanDependencies.values()
+                .stream()
+                .map(dependency -> resolveDependencyName(dependency, beanDefinition, container))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+            Map<String, BeanDependency> oldDependencies = Map.copyOf(beanDependencies);
+
+            oldToNewNames.forEach(namePair -> replaceOldName(namePair, beanDependencies));
+            if (oldDependencies.size() != beanDependencies.size()) {
+                throw new BeanInstanceCreationException(format("Bean named `%s` has a supertype and one of its subtypes" +
+                    " in dependencies and they have the same candidate for injection", beanDefinition.name()));
+            }
+        }
+    }
+
+    private void replaceOldName(Pair<String, String> oldNameToNewName, Map<String, BeanDependency> beanDependencies) {
+        String oldName = oldNameToNewName.getLeft();
+        String newName = oldNameToNewName.getRight();
+        BeanDependency oldDependency = beanDependencies.remove(oldName);
+        oldDependency.setName(newName);
+        beanDependencies.put(newName, oldDependency);
+    }
+
+    @Nullable
+    private Pair<String, String> resolveDependencyName(BeanDependency targetDependency,
+                                                       BeanDefinition rootDefinition,
+                                                       BeanDefinitionContainer container) {
+        String dependencyName = targetDependency.getName();
+        Class<?> dependencyType = targetDependency.getType();
+
+        if (container.getBeanDefinitionByName(dependencyName).isPresent()) {
+            return null;
+        }
+
+        List<BeanDefinition> sameTypeBeans = container.getBeansWithExactType(dependencyType);
+
+        List<BeanDefinition> sameTypeBeansCopy = new ArrayList<>(sameTypeBeans);
+        sameTypeBeansCopy.remove(rootDefinition);
+
+        Optional<BeanDefinition> optionalDependency;
+        optionalDependency = findMatchingDependencyFirstTry(sameTypeBeansCopy);
+
+        BeanDefinition matchingDependency;
+        if (optionalDependency.isEmpty()) {
+            List<BeanDefinition> assignableBeans = container.getBeansAssignableFromType(dependencyType);
+
+            List<BeanDefinition> assignableBeansCopy = new ArrayList<>(assignableBeans);
+            assignableBeansCopy.remove(rootDefinition);
+
+            matchingDependency = findMatchingDependency(assignableBeansCopy, targetDependency, rootDefinition);
+        } else {
+            matchingDependency = optionalDependency.orElseThrow(() ->
+                new MissingDependencyException(String.format(MISSING_DEPENDENCY_EXCEPTION, dependencyType, dependencyName,
+                    rootDefinition.name())));
+        }
+
+        String newDependencyName = matchingDependency.name();
+        if (newDependencyName.equals(dependencyName)) {
+            return null;
+        }
+
+        return Pair.of(dependencyName, newDependencyName);
+    }
+
+    private Supplier<String> getMatchingBeanMessage(List<BeanDefinition> beanDefinitions) {
+        return () -> beanDefinitions.stream()
+            .map(beanDefinition -> beanDefinition.name() + ": " + beanDefinition.type().getSimpleName())
+            .collect(joining(", "));
+    }
+
+
+    private Optional<BeanDefinition> findMatchingDependencyFirstTry(List<BeanDefinition> dependencies) {
+        if (dependencies.size() > 1) {
+            return dependencies.stream()
+                .filter(BeanDefinition::isPrimary)
+                .findFirst();
+        }
+        return dependencies.stream().findFirst();
+    }
+    private BeanDefinition findMatchingDependency(List<BeanDefinition> dependencies, BeanDependency targetDependency,
+                                                  BeanDefinition rootDefinition) {
+        if (dependencies.size() > 1) {
+            Supplier<String> errorMessageSupplier = getMatchingBeanMessage(dependencies);
+
+            return dependencies.stream()
+                .filter(BeanDefinition::isPrimary)
+                .findFirst()
+                .orElseThrow(() -> new NoUniqueBeanException(format(NO_UNIQUE_BEAN_EXCEPTION,
+                    targetDependency.getType().getSimpleName(), errorMessageSupplier.get())));
+        }
+        return dependencies.stream().findFirst().orElseThrow(() ->
+            new MissingDependencyException(String.format(MISSING_DEPENDENCY_EXCEPTION, targetDependency.getType(),
+                targetDependency.getName(),
+                rootDefinition.name())));
+    }
+}

--- a/src/main/java/com/hoverla/bring/context/bean/initializer/BeanInitializer.java
+++ b/src/main/java/com/hoverla/bring/context/bean/initializer/BeanInitializer.java
@@ -1,0 +1,65 @@
+package com.hoverla.bring.context.bean.initializer;
+
+import com.hoverla.bring.context.bean.definition.BeanDefinition;
+import com.hoverla.bring.context.bean.definition.BeanDefinitionContainer;
+import com.hoverla.bring.context.bean.dependency.BeanDependency;
+import com.hoverla.bring.context.bean.dependency.BeanDependencyNameResolver;
+import com.hoverla.bring.exception.BeanInitializePhaseException;
+import com.hoverla.bring.exception.NoSuchBeanException;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Collection;
+
+import static com.hoverla.bring.exception.NoSuchBeanException.NO_SUCH_BEAN_EXCEPTION_BY_NAME_TYPE;
+import static java.lang.String.format;
+
+@RequiredArgsConstructor
+public class BeanInitializer {
+    private final BeanDependencyNameResolver dependencyNameResolver;
+
+    public void initialize(BeanDefinitionContainer container) {
+        dependencyNameResolver.resolveDependencyNames(container);
+
+        Collection<BeanDefinition> beanDefinitions = container.getBeanDefinitions();
+        try {
+            beanDefinitions.forEach(beanDefinition -> doInitialize(beanDefinition, container));
+        } catch (Exception ex) {
+            throw new BeanInitializePhaseException("Can't initialize beans", ex);
+        }
+    }
+
+    private void doInitialize(BeanDefinition definitionToInitialize, BeanDefinitionContainer container) {
+        if (definitionToInitialize.isInstantiated()) {
+            return;
+        }
+
+        BeanDefinition[] beanDependencies = getBeanDependencies(definitionToInitialize, container);
+        if (beanDependencies.length == 0) {
+            definitionToInitialize.instantiate();
+            return;
+        }
+
+        for (BeanDefinition beanDependency : beanDependencies) {
+            if (!beanDependency.isInstantiated()) {
+                doInitialize(beanDependency, container);
+            }
+        }
+        definitionToInitialize.instantiate(beanDependencies);
+    }
+
+    private BeanDefinition[] getBeanDependencies(BeanDefinition rootDefinition, BeanDefinitionContainer container) {
+        return rootDefinition.dependencies()
+            .values()
+            .stream()
+            .map(dependency -> getDependency(dependency, rootDefinition, container))
+            .toArray(BeanDefinition[]::new);
+    }
+
+    private BeanDefinition getDependency(BeanDependency dependency, BeanDefinition rootDefinition,
+                                         BeanDefinitionContainer container) {
+        return container
+            .getBeanDefinitionByName(dependency.getName())
+            .orElseThrow(() -> new NoSuchBeanException(format(NO_SUCH_BEAN_EXCEPTION_BY_NAME_TYPE,
+                dependency.getName(), rootDefinition.name())));
+    }
+}

--- a/src/main/java/com/hoverla/bring/context/bean/postprocessor/AutowiringPostProcessor.java
+++ b/src/main/java/com/hoverla/bring/context/bean/postprocessor/AutowiringPostProcessor.java
@@ -1,4 +1,4 @@
-package com.hoverla.bring.context.postprocessor;
+package com.hoverla.bring.context.bean.postprocessor;
 
 import com.hoverla.bring.annotation.Autowired;
 import com.hoverla.bring.context.ApplicationContext;
@@ -9,6 +9,7 @@ import java.lang.reflect.Field;
 public class AutowiringPostProcessor implements PostProcessor {
 
     @Override
+    @SuppressWarnings("java:S3011")
     public void process(Object beanInstance, ApplicationContext applicationContext) {
         for (Field field : beanInstance.getClass().getDeclaredFields()) {
             if (field.isAnnotationPresent(Autowired.class)) {

--- a/src/main/java/com/hoverla/bring/context/bean/postprocessor/PostProcessor.java
+++ b/src/main/java/com/hoverla/bring/context/bean/postprocessor/PostProcessor.java
@@ -1,4 +1,4 @@
-package com.hoverla.bring.context.postprocessor;
+package com.hoverla.bring.context.bean.postprocessor;
 
 import com.hoverla.bring.context.ApplicationContext;
 

--- a/src/main/java/com/hoverla/bring/context/bean/postprocessor/SetterAutowiringPostProcessor.java
+++ b/src/main/java/com/hoverla/bring/context/bean/postprocessor/SetterAutowiringPostProcessor.java
@@ -1,4 +1,4 @@
-package com.hoverla.bring.context.postprocessor;
+package com.hoverla.bring.context.bean.postprocessor;
 
 import com.hoverla.bring.annotation.Autowired;
 import com.hoverla.bring.context.ApplicationContext;

--- a/src/main/java/com/hoverla/bring/context/bean/postprocessor/ValueAnnotationProcessor.java
+++ b/src/main/java/com/hoverla/bring/context/bean/postprocessor/ValueAnnotationProcessor.java
@@ -1,4 +1,4 @@
-package com.hoverla.bring.context.postprocessor;
+package com.hoverla.bring.context.bean.postprocessor;
 
 
 import com.hoverla.bring.annotation.Value;
@@ -24,6 +24,7 @@ public class ValueAnnotationProcessor implements PostProcessor {
     }
 
     @Override
+    @SuppressWarnings("java:S3011")
     public void process(Object beanInstance, ApplicationContext applicationContext) {
         for (Field field : beanInstance.getClass().getDeclaredFields()) {
             try {

--- a/src/main/java/com/hoverla/bring/context/bean/scanner/BeanAnnotationScanner.java
+++ b/src/main/java/com/hoverla/bring/context/bean/scanner/BeanAnnotationScanner.java
@@ -1,0 +1,40 @@
+package com.hoverla.bring.context.bean.scanner;
+
+import com.hoverla.bring.annotation.Bean;
+import com.hoverla.bring.context.bean.definition.BeanDefinitionMapper;
+import com.hoverla.bring.context.bean.definition.BeanDefinition;
+import org.reflections.Reflections;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class BeanAnnotationScanner implements BeanScanner{
+
+    private final BeanDefinitionMapper mapper;
+
+    private final String[] packagesToScan;
+
+    public BeanAnnotationScanner(BeanDefinitionMapper mapper,
+                                 String... packagesToScan) {
+        this.mapper = mapper;
+        this.packagesToScan = packagesToScan;
+    }
+
+
+    @Override
+    public List<BeanDefinition> scan() {
+        Reflections reflectionScanner = new Reflections((Object[]) this.packagesToScan);
+        Set<Class<?>> beanClasses = reflectionScanner.getTypesAnnotatedWith(Bean.class);
+
+        if (beanClasses.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        //TODO add validation for bean classes
+        return beanClasses.stream()
+            .map(mapper::mapToBeanDefinition)
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/hoverla/bring/context/bean/scanner/BeanScanner.java
+++ b/src/main/java/com/hoverla/bring/context/bean/scanner/BeanScanner.java
@@ -1,0 +1,9 @@
+package com.hoverla.bring.context.bean.scanner;
+
+import com.hoverla.bring.context.bean.definition.BeanDefinition;
+
+import java.util.List;
+
+public interface BeanScanner {
+    List<BeanDefinition> scan();
+}

--- a/src/main/java/com/hoverla/bring/context/bean/scanner/ConfigurationBeanScanner.java
+++ b/src/main/java/com/hoverla/bring/context/bean/scanner/ConfigurationBeanScanner.java
@@ -1,0 +1,62 @@
+package com.hoverla.bring.context.bean.scanner;
+
+import com.hoverla.bring.annotation.Bean;
+import com.hoverla.bring.annotation.Configuration;
+import com.hoverla.bring.context.bean.definition.BeanDefinitionMapper;
+import com.hoverla.bring.context.bean.definition.BeanDefinition;
+import lombok.SneakyThrows;
+import org.reflections.Reflections;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
+public class ConfigurationBeanScanner implements BeanScanner {
+    private final String[] packagesToScan;
+    private final BeanDefinitionMapper mapper;
+
+    public ConfigurationBeanScanner(BeanDefinitionMapper mapper,
+                                         String... packagesToScan) {
+        this.packagesToScan = packagesToScan;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public List<BeanDefinition> scan() {
+        Reflections reflections = new Reflections((Object[]) packagesToScan);
+        Set<Class<?>> configurationClasses = reflections.getTypesAnnotatedWith(Configuration.class);
+
+        if (configurationClasses.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return configurationClasses.stream()
+            .map(this::scanBeanConfigMethods)
+            .flatMap(List::stream)
+            .collect(toList());
+    }
+
+    private List<BeanDefinition> scanBeanConfigMethods(Class<?> configurationClass) {
+        //TODO add validation for @Configuration class
+        Object configuration = createConfigurationInstance(configurationClass);
+
+        return resolveBeanMethods(configurationClass).stream()
+            .map(method -> mapper.mapToBeanDefinition(configuration, method))
+            .collect(toList());
+    }
+
+    private List<Method> resolveBeanMethods(Class<?> configClass) {
+        return Stream.of(configClass.getMethods())
+            .filter(m -> m.isAnnotationPresent(Bean.class))
+            .collect(toList());
+    }
+
+    @SneakyThrows
+    private Object createConfigurationInstance(Class<?> configClass) {
+        return configClass.getConstructor().newInstance();
+    }
+}

--- a/src/main/java/com/hoverla/bring/context/util/ResolveDependenciesUtil.java
+++ b/src/main/java/com/hoverla/bring/context/util/ResolveDependenciesUtil.java
@@ -1,0 +1,66 @@
+package com.hoverla.bring.context.util;
+
+import com.hoverla.bring.context.bean.definition.BeanDefinition;
+import com.hoverla.bring.exception.BeanDependencyInjectionException;
+
+import java.lang.reflect.Parameter;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.String.format;
+
+public class ResolveDependenciesUtil {
+
+    private ResolveDependenciesUtil() {
+    }
+
+    public static void resolveDependencies(List<BeanDefinition> dependencies, List<Parameter> parameters,
+                                     Object[] constructorArgs, String name) {
+        Map<Integer, Parameter> params = new LinkedHashMap<>();
+        for (int i = 0; i < parameters.size(); i++) {
+            params.put(i, parameters.get(i));
+        }
+        params
+            .entrySet()
+            .stream()
+            .sorted(ResolveDependenciesUtil::subclassesFirst)
+            .forEachOrdered(entry -> resolveArgumentFromEntry(entry, dependencies, constructorArgs, name));
+    }
+
+    private static int subclassesFirst(Map.Entry<Integer, Parameter> parameterEntry1,
+                                       Map.Entry<Integer, Parameter> parameterEntry2) {
+        Class<?> type1 = parameterEntry1.getValue().getType();
+        Class<?> type2 = parameterEntry2.getValue().getType();
+        if (type1.isAssignableFrom(type2)) {
+            return 1;
+        }
+        return -1;
+    }
+
+    private static void resolveArgumentFromEntry(Map.Entry<Integer, Parameter> indexedParameter,
+                                          List<BeanDefinition> dependencies, Object[] constructorArgs, String name) {
+        Integer index = indexedParameter.getKey();
+        Parameter parameter = indexedParameter.getValue();
+        Object matchingArgument = getBeanDefinitionByParameter(parameter, dependencies, name).getInstance();
+        constructorArgs[index] = matchingArgument;
+    }
+
+    private static BeanDefinition getBeanDefinitionByParameter(Parameter parameter, List<BeanDefinition> dependencies,
+                                                               String name) {
+        BeanDefinition beanDefinition = dependencies.stream()
+            .filter(bd -> parameterMatch(parameter, bd))
+            .findFirst()
+            .orElseThrow(() -> new BeanDependencyInjectionException(format(
+                "'%s' bean has no dependency that matches parameter '%s'", name, parameter.getType().getName())));
+
+        dependencies.remove(beanDefinition);
+        return beanDefinition;
+    }
+
+    @SuppressWarnings("java:S2589")
+    private static boolean parameterMatch(Parameter parameter, BeanDefinition dependencyToMatch) {
+        Class<?> parameterType = parameter.getType();
+        return parameterType.isAssignableFrom(dependencyToMatch.type());
+    }
+}

--- a/src/main/java/com/hoverla/bring/exception/BeanDependencyInjectionException.java
+++ b/src/main/java/com/hoverla/bring/exception/BeanDependencyInjectionException.java
@@ -1,0 +1,7 @@
+package com.hoverla.bring.exception;
+
+public class BeanDependencyInjectionException extends RuntimeException {
+    public BeanDependencyInjectionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/hoverla/bring/exception/BeanInitializePhaseException.java
+++ b/src/main/java/com/hoverla/bring/exception/BeanInitializePhaseException.java
@@ -1,0 +1,7 @@
+package com.hoverla.bring.exception;
+
+public class BeanInitializePhaseException extends RuntimeException {
+    public BeanInitializePhaseException(String message, Exception cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/hoverla/bring/exception/BeanInstanceCreationException.java
+++ b/src/main/java/com/hoverla/bring/exception/BeanInstanceCreationException.java
@@ -1,0 +1,11 @@
+package com.hoverla.bring.exception;
+
+public class BeanInstanceCreationException extends RuntimeException {
+
+    public BeanInstanceCreationException(String message) {
+        super(message);
+    }
+    public BeanInstanceCreationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/hoverla/bring/exception/MissingDependencyException.java
+++ b/src/main/java/com/hoverla/bring/exception/MissingDependencyException.java
@@ -1,0 +1,10 @@
+package com.hoverla.bring.exception;
+
+public class MissingDependencyException extends RuntimeException {
+
+    public static final String MISSING_DEPENDENCY_EXCEPTION = "Dependency of type %s and name %s hasn't been found for [%s] bean";
+
+    public MissingDependencyException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/com/hoverla/bring/context/bean/definition/BeanDefinitionMapperTest.java
+++ b/src/test/java/com/hoverla/bring/context/bean/definition/BeanDefinitionMapperTest.java
@@ -1,0 +1,34 @@
+package com.hoverla.bring.context.bean.definition;
+
+import com.hoverla.bring.context.fixtures.bean.success.TestBeanWithoutName;
+import com.hoverla.bring.context.fixtures.config.TestConfiguration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BeanDefinitionMapperTest {
+
+    private final BeanDefinitionMapper mapper = new BeanDefinitionMapper();
+
+    @Test
+    @DisplayName("Configuration class bean is mapped to ConfigurationBeanDefinition")
+    void configurationClassIsMappedToConfigurationBeanDefinition() throws NoSuchMethodException {
+        TestConfiguration beanConfigClass = new TestConfiguration();
+        Method beanMethod = beanConfigClass.getClass().getMethod("namedBean");
+
+        BeanDefinition beanDefinition = mapper.mapToBeanDefinition(beanConfigClass, beanMethod);
+
+        assertTrue(beanDefinition instanceof ConfigurationBeanDefinition);
+    }
+
+    @Test
+    @DisplayName("Default bean is mapped to DefaultBeanDefinition")
+    void defaultBeanIsMappedToDefaultBeanDefinition() {
+        BeanDefinition beanDefinition = mapper.mapToBeanDefinition(TestBeanWithoutName.class);
+
+        assertTrue(beanDefinition instanceof DefaultBeanDefinition);
+    }
+}

--- a/src/test/java/com/hoverla/bring/context/bean/definition/ConfigurationBeanDefinitionTest.java
+++ b/src/test/java/com/hoverla/bring/context/bean/definition/ConfigurationBeanDefinitionTest.java
@@ -1,0 +1,135 @@
+package com.hoverla.bring.context.bean.definition;
+
+import com.hoverla.bring.annotation.Bean;
+import com.hoverla.bring.context.bean.dependency.BeanDependency;
+import com.hoverla.bring.context.fixtures.config.TestConfiguration;
+import com.hoverla.bring.exception.BeanDependencyInjectionException;
+import com.hoverla.bring.exception.BeanInstanceCreationException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ConfigurationBeanDefinitionTest {
+
+    private TestConfiguration testConfiguration;
+
+    @BeforeEach
+    void setUp() {
+        testConfiguration = new TestConfiguration();
+    }
+
+    @Test
+    @DisplayName("Bean name is taken from method name if it's not specified via annotation")
+    void unnamedBean() throws NoSuchMethodException {
+        String methodName = "unnamedBean";
+        Method method = testConfiguration.getClass().getMethod(methodName);
+
+        BeanDefinition beanDefinition = new ConfigurationBeanDefinition(testConfiguration, method);
+
+        assertNotNull(beanDefinition);
+        assertEquals(methodName, beanDefinition.name());
+    }
+
+    @Test
+    @DisplayName("Bean name is taken from @Bean annotation value")
+    void beanWithNameInAnnotation() throws NoSuchMethodException {
+        Method method = testConfiguration.getClass().getMethod("namedBean");
+        String beanName = method.getAnnotation(Bean.class).value();
+        Class<?> returnType = method.getReturnType();
+
+        BeanDefinition beanDefinition = new ConfigurationBeanDefinition(testConfiguration, method);
+
+        assertNotNull(beanDefinition);
+        assertEquals(beanName, beanDefinition.name());
+        assertEquals(returnType, beanDefinition.type());
+    }
+
+
+    @Test
+    @DisplayName("Bean dependencies match their parameter name")
+    void beanWithDependencies() throws NoSuchMethodException {
+        String methodName = "beanWithDependencies";
+        Method method = testConfiguration.getClass().getMethod(methodName, long.class, String.class);
+
+        BeanDefinition firstDependency = mock(BeanDefinition.class);
+        when(firstDependency.getInstance()).thenReturn(101L);
+        BeanDefinition secondDependency = mock(BeanDefinition.class);
+        when(secondDependency.getInstance()).thenReturn("23");
+
+        BeanDependency longDependency = new BeanDependency(long.class.getName(), Long.class);
+        BeanDependency stringDependency = new BeanDependency(String.class.getName(), String.class);
+        var dependencies = Map.of(longDependency.getName(), longDependency, stringDependency.getName(), stringDependency);
+
+        BeanDefinition beanDefinition = new ConfigurationBeanDefinition(testConfiguration, method);
+
+        assertNotNull(beanDefinition);
+        assertEquals(dependencies, beanDefinition.dependencies());
+    }
+
+    @Test
+    @DisplayName("Missing dependencies cause BeanInstanceCreationException")
+    void beanWithMissingDependencies() throws NoSuchMethodException {
+        String methodName = "beanWithDependencies";
+        Method method = testConfiguration.getClass().getMethod(methodName, long.class, String.class);
+
+        BeanDefinition beanDefinition = new ConfigurationBeanDefinition(testConfiguration, method);
+
+        Assertions.assertThatThrownBy(beanDefinition::instantiate)
+            .isInstanceOf(BeanInstanceCreationException.class)
+            .hasMessageContaining("Bean with name 'beanWithDependencies' can't be instantiated")
+            .hasRootCauseInstanceOf(BeanDependencyInjectionException.class)
+            .hasStackTraceContaining("bean has no dependency that matches parameter");
+    }
+
+    @Test
+    @DisplayName("Beans are instantiated only on instantiate method call")
+    void beansAreInstantiatedLazily() throws NoSuchMethodException {
+        Method method = testConfiguration.getClass().getMethod("namedBean");
+
+        var beanDefinition = new ConfigurationBeanDefinition(testConfiguration, method);
+        assertNull(beanDefinition.getInstance());
+
+        beanDefinition.instantiate();
+        assertNotNull(beanDefinition.getInstance());
+    }
+
+    @Test
+    @DisplayName("Bean constructor dependencies are kept in order")
+    void beanConstructorWithCorrectArgumentsOrder() throws NoSuchMethodException {
+        Method method = testConfiguration.getClass().getMethod("beanWithDependencies", long.class,
+            String.class);
+
+        long n = 101L;
+        BeanDefinition firstDependency = mock(BeanDefinition.class);
+        when(firstDependency.getInstance()).thenReturn(n);
+        doReturn(long.class).when(firstDependency).type();
+
+
+        String s = "23";
+        BeanDefinition secondDependency = mock(BeanDefinition.class);
+        when(secondDependency.getInstance()).thenReturn(s);
+        doReturn(String.class).when(secondDependency).type();
+
+
+        var beanDefinition = new ConfigurationBeanDefinition(testConfiguration, method);
+
+        assertThatNoException()
+            .isThrownBy(() -> beanDefinition.instantiate(secondDependency, firstDependency));
+
+        Object instance = beanDefinition.getInstance();
+
+        assertEquals(n - Long.parseLong(s), instance);
+    }
+}

--- a/src/test/java/com/hoverla/bring/context/bean/definition/DefaultBeanDefinitionTest.java
+++ b/src/test/java/com/hoverla/bring/context/bean/definition/DefaultBeanDefinitionTest.java
@@ -1,0 +1,256 @@
+package com.hoverla.bring.context.bean.definition;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Stream;
+
+import com.hoverla.bring.annotation.Bean;
+import com.hoverla.bring.context.bean.dependency.BeanDependency;
+import com.hoverla.bring.context.fixtures.autowired.definition.success.BeanWithAutowiredConstructor;
+import com.hoverla.bring.context.fixtures.autowired.definition.success.BeanWithCombinedAutowired;
+import com.hoverla.bring.context.fixtures.autowired.definition.success.BeanWithConstructor;
+import com.hoverla.bring.context.fixtures.autowired.definition.success.BeanWithMultipleAutowiredFields;
+import com.hoverla.bring.context.fixtures.autowired.definition.success.BeanWithSetterAutowiring;
+import com.hoverla.bring.context.fixtures.bean.success.TestBeanWithoutName;
+import com.hoverla.bring.exception.BeanDependencyInjectionException;
+import com.hoverla.bring.exception.BeanInstanceCreationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DefaultBeanDefinitionTest {
+
+    @ParameterizedTest(name = "[{index}] - Resolve bean dependencies - {2}")
+    @MethodSource("resolveDependencies")
+    void resolveBeanDependenciesTest(Class<?> beanClass, Map<String, BeanDependency> expectedDependencies, String description) {
+        var beanDefinition = new DefaultBeanDefinition(beanClass);
+        assertEquals(expectedDependencies, beanDefinition.dependencies());
+    }
+
+    @ParameterizedTest(name = "[{index}] - Resolve bean name - {2}")
+    @MethodSource("resolveBeanNames")
+    void resolveBeanNameTest(Class<?> beanClass, String expectedName, String description) {
+        var beanDefinition = new DefaultBeanDefinition(beanClass);
+
+        assertEquals(expectedName, beanDefinition.name());
+    }
+
+    @Test
+    @DisplayName("Successful instantiation of bean without dependencies")
+    void createBeanWithoutDependencies() {
+        Class<?> beanClass = TestBeanWithoutName.class;
+        var beanDefinition = new DefaultBeanDefinition(beanClass);
+
+        beanDefinition.instantiate();
+        Object instance = beanDefinition.getInstance();
+
+        assertNotNull(instance);
+        assertEquals(beanClass, beanDefinition.type());
+    }
+
+    @Test
+    @DisplayName("Successful instantiation of a bean with @Autowired constructor")
+    void createBeanWithAutowiredConstructor() {
+        Class<?> beanClass = BeanWithAutowiredConstructor.class;
+        var beanDefinition = new DefaultBeanDefinition(beanClass);
+
+        var fieldOne = "String";
+        var fieldTwo = LocalDate.of(2023, Month.FEBRUARY, 8);
+        BeanDefinition dependencyOne = getDefinition(String.class, String.class.getName(), fieldOne);
+        BeanDefinition dependencyTwo = getDefinition(LocalDate.class, LocalDate.class.getName(), fieldTwo);
+
+        beanDefinition.instantiate(dependencyOne, dependencyTwo);
+        Object instance = beanDefinition.getInstance();
+
+        assertNotNull(instance);
+        BeanWithAutowiredConstructor beanInstance = (BeanWithAutowiredConstructor) instance;
+        assertEquals(fieldOne, beanInstance.getString());
+        assertEquals(fieldTwo, beanInstance.getDate());
+    }
+
+    @Test
+    @DisplayName("Successful instantiation of a bean with default constructor")
+    void createBeanWithDefaultConstructor() {
+        Class<?> beanClass = BeanWithConstructor.class;
+        var beanDefinition = new DefaultBeanDefinition(beanClass);
+
+        var fieldOne = "String";
+        var fieldTwo = LocalDate.of(2023, Month.FEBRUARY, 8);
+        BeanDefinition dependencyOne = getDefinition(String.class, String.class.getName(), fieldOne);
+        BeanDefinition dependencyTwo = getDefinition(LocalDate.class, LocalDate.class.getName(), fieldTwo);
+
+        beanDefinition.instantiate(dependencyOne, dependencyTwo);
+        Object instance = beanDefinition.getInstance();
+
+        assertNotNull(instance);
+        BeanWithConstructor beanInstance = (BeanWithConstructor) instance;
+        assertEquals(fieldOne, beanInstance.getString());
+        assertEquals(fieldTwo, beanInstance.getDate());
+    }
+
+    @Test
+    @DisplayName("Unsuccessful instantiation of bean with 2-argument default constructor. Constructor parameters do not match")
+    void createBeanWithNotMatchingConstructorDependencies() {
+        Class<?> beanClass = BeanWithConstructor.class;
+        var beanDefinition = new DefaultBeanDefinition(beanClass);
+
+        var fieldOne = "String";
+        var fieldTwo = "NextString";
+        BeanDefinition dependencyOne = getDefinition(String.class, "gg", fieldOne);
+        BeanDefinition dependencyTwo = getDefinition(String.class, "wp", fieldTwo);
+
+        BeanInstanceCreationException exception = assertThrows(BeanInstanceCreationException.class,
+            () -> beanDefinition.instantiate(dependencyOne, dependencyTwo));
+
+        assertEquals("Bean with name 'someBean' can't be instantiated",
+            exception.getMessage());
+        assertEquals(BeanDependencyInjectionException.class, exception.getCause().getClass());
+    }
+
+    @Test
+    @DisplayName("Successful instantiation of bean with 3 @Autowired fields")
+    void createBeanWithAutowiredFields() {
+        Class<?> beanClass = BeanWithMultipleAutowiredFields.class;
+        var beanDefinition = new DefaultBeanDefinition(beanClass);
+
+        var fieldOne = new TestBeanWithoutName();
+        var fieldTwo = "23";
+        var fieldThree = 1.2D;
+        BeanDefinition dependencyOne = getDefinition(TestBeanWithoutName.class, TestBeanWithoutName.class.getName(),
+            fieldOne);
+        BeanDefinition dependencyTwo = getDefinition(String.class, String.class.getName(), fieldTwo);
+        BeanDefinition dependencyThree = getDefinition(Double.class, Double.class.getName(), fieldThree);
+
+        beanDefinition.instantiate(dependencyOne, dependencyTwo, dependencyThree);
+        Object instance = beanDefinition.getInstance();
+
+        assertNotNull(instance);
+        BeanWithMultipleAutowiredFields beanInstance = (BeanWithMultipleAutowiredFields) instance;
+        assertEquals(fieldOne, beanInstance.getTestBeanWithoutName());
+        assertEquals(fieldTwo, beanInstance.getString());
+        assertEquals(fieldThree, beanInstance.getADouble());
+    }
+
+    @Test
+    @DisplayName("Unsuccessful instantiation of bean with 3 @Autowired fields. Only 2 field matched and autowired.")
+    void createBeanWithNotMatchingFieldDependencies() {
+        Class<?> beanClass = BeanWithMultipleAutowiredFields.class;
+        var beanDefinition = new DefaultBeanDefinition(beanClass);
+
+        BeanDefinition allGood = getDefinition(TestBeanWithoutName.class, "gg", new TestBeanWithoutName());
+        BeanDefinition wrongNameAndType = getDefinition(Integer.class, "name", 23);
+        BeanDefinition allGoodTwo = getDefinition(Double.class, Double.class.getName(), 1.2D);
+
+        BeanInstanceCreationException exception = assertThrows(BeanInstanceCreationException.class,
+            () -> beanDefinition.instantiate(allGood, wrongNameAndType, allGoodTwo));
+
+        assertEquals("Bean with name " +
+            "'com.hoverla.bring.context.fixtures.autowired.definition.success.BeanWithMultipleAutowiredFields' " +
+            "can't be instantiated", exception.getMessage());
+        assertEquals(BeanDependencyInjectionException.class, exception.getCause().getClass());
+        assertEquals("Field injection failed for bean instance of type " +
+            "com.hoverla.bring.context.fixtures.autowired.definition.success.BeanWithMultipleAutowiredFields. " +
+            "Unresolved fields: [string]", exception.getCause().getMessage());
+    }
+
+    @Test
+    @DisplayName("Successful instantiation of bean with both @Autowired constructor and @Autowired field")
+    void createBeanWithBothAutowiredConstructorAndFields() {
+        Class<?> beanClass = BeanWithCombinedAutowired.class;
+        var beanDefinition = new DefaultBeanDefinition(beanClass);
+
+        var fieldOne = "str";
+        var fieldTwo = LocalDate.of(2023, Month.FEBRUARY, 9);
+        BeanDefinition dependencyOne = getDefinition(BeanWithAutowiredConstructor.class, BeanWithAutowiredConstructor.class.getName(),
+            new BeanWithAutowiredConstructor(fieldOne, fieldTwo));
+        BeanDefinition dependencyTwo = getDefinition(BeanWithConstructor.class, BeanWithConstructor.class.getName(),
+            new BeanWithConstructor(fieldOne, fieldTwo));
+
+        beanDefinition.instantiate(dependencyOne, dependencyTwo);
+        Object instance = beanDefinition.getInstance();
+
+        assertNotNull(instance);
+
+        BeanWithCombinedAutowired bean = (BeanWithCombinedAutowired) instance;
+        assertEquals(fieldOne, bean.getBeanWithConstructor().getString());
+        assertEquals(fieldTwo, bean.getBeanWithConstructor().getDate());
+
+        assertEquals(fieldOne, bean.getBeanWithAutowiredConstructor().getString());
+        assertEquals(fieldTwo, bean.getBeanWithAutowiredConstructor().getDate());
+
+
+    }
+
+    private Stream<Arguments> resolveDependencies() {
+        return Stream.of(
+            Arguments.of(BeanWithConstructor.class,
+                Map.ofEntries(
+                    getDependency(String.class),
+                    getDependency(LocalDate.class)
+                ),
+                "Default constructor dependencies are resolved"
+            ),
+            Arguments.of(BeanWithAutowiredConstructor.class,
+                Map.ofEntries(
+                    getDependency(String.class),
+                    getDependency(LocalDate.class)
+                ),
+                "@Autowired constructor dependencies are resolved"
+            ),
+            Arguments.of(BeanWithCombinedAutowired.class,
+                Map.ofEntries(
+                    getDependency(BeanWithAutowiredConstructor.class),
+                    getDependency(BeanWithConstructor.class)
+                ),
+                "@Autowired constructor and field dependencies are resolved"
+            ),
+            Arguments.of(BeanWithSetterAutowiring.class,
+                Map.ofEntries(
+                    getDependency(BeanWithAutowiredConstructor.class),
+                    getDependency(BeanWithConstructor.class),
+                    getDependency(Double.class)
+                ),
+                "@Autowired field dependencies are resolved"
+            )
+        );
+    }
+
+    private Entry<String, BeanDependency> getDependency(Class<?> beanType) {
+        return Map.entry(
+            beanType.getName(),
+            new BeanDependency(beanType.getName(), beanType)
+        );
+    }
+
+    private Stream<Arguments> resolveBeanNames() {
+        return Stream.of(
+            Arguments.of(BeanWithConstructor.class, BeanWithConstructor.class.getAnnotation(Bean.class).value(),
+                "Name is resolved from @Bean annotation value"),
+            Arguments.of(BeanWithSetterAutowiring.class, BeanWithSetterAutowiring.class.getName(),
+                "Name is resolved from bean type")
+        );
+    }
+
+    private BeanDefinition getDefinition(Class<?> type, String name, Object instance) {
+        BeanDefinition beanDefinition = mock(BeanDefinition.class);
+        doReturn(type).when(beanDefinition).type();
+        when(beanDefinition.name()).thenReturn(name);
+        when(beanDefinition.getInstance()).thenReturn(instance);
+
+        return beanDefinition;
+    }
+}

--- a/src/test/java/com/hoverla/bring/context/bean/dependency/BeanNameResolverTest.java
+++ b/src/test/java/com/hoverla/bring/context/bean/dependency/BeanNameResolverTest.java
@@ -1,0 +1,83 @@
+package com.hoverla.bring.context.bean.dependency;
+
+import com.hoverla.bring.context.bean.definition.BeanDefinition;
+import com.hoverla.bring.context.bean.definition.BeanDefinitionContainer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BeanNameResolverTest {
+    private BeanDependencyNameResolver nameResolver;
+
+    @BeforeEach
+    void setUp() {
+        nameResolver = new BeanDependencyNameResolver();
+    }
+
+    @Test
+    @DisplayName("Replace bean name with a custom name from bean definition")
+    void replaceDefaultNameToCustomTest() {
+        var beanName = "date";
+        BeanDefinition dependencyDefinition = getDefinition(beanName, LocalDate.class, emptyMap());
+
+        BeanDependency dependency = new BeanDependency(LocalDate.class.getName(), LocalDate.class);
+        Map<String, BeanDependency> dependencies = new HashMap<>(Map.of(LocalDate.class.getName(), dependency));
+        BeanDefinition dependentDefinition = getDefinition("beanWithDependencies", Object.class, dependencies);
+
+        List<BeanDefinition> beans = List.of(dependencyDefinition, dependentDefinition);
+        BeanDefinitionContainer container = new BeanDefinitionContainer(beans);
+
+        nameResolver.resolveDependencyNames(container);
+
+        Map<String, BeanDependency> definitionDependencies = dependentDefinition.dependencies();
+        assertTrue(definitionDependencies.containsKey(beanName));
+        assertEquals(dependency, definitionDependencies.get(beanName));
+    }
+
+    @Test
+    @DisplayName("Replaces default dependency names with primary bean custom when there are more than 1 bean of the same type")
+    void replacesDefaultNameToPrimaryBeanName() {
+        BeanDefinition nonPrimaryDependency = getDefinition("string1", String.class, emptyMap());
+        BeanDefinition primaryDependency = getDefinition("string2", String.class, emptyMap());
+        when(primaryDependency.isPrimary()).thenReturn(true);
+
+        BeanDependency dependency = new BeanDependency(String.class.getName(), String.class);
+        Map<String, BeanDependency> dependencies = new HashMap<>(Map.of(dependency.getName(), dependency));
+        BeanDefinition dependentDefinition = getDefinition("bean", Object.class, dependencies);
+
+        List<BeanDefinition> beans = List.of(nonPrimaryDependency, primaryDependency, dependentDefinition);
+        BeanDefinitionContainer container = new BeanDefinitionContainer(beans);
+
+        nameResolver.resolveDependencyNames(container);
+
+        Map<String, BeanDependency> definitionDependencies = dependentDefinition.dependencies();
+        assertTrue(definitionDependencies.containsKey(primaryDependency.name()));
+        assertFalse(definitionDependencies.containsKey(nonPrimaryDependency.name()));
+
+        assertThat(dependentDefinition.dependencies())
+            .containsKey(primaryDependency.name())
+            .doesNotContainKeys(Integer.class.getName(), nonPrimaryDependency.name());
+    }
+
+    private BeanDefinition getDefinition(String beanName, Class<?> type, Map<String, BeanDependency> dependencies) {
+        BeanDefinition beanDefinition = mock(BeanDefinition.class);
+        doReturn(type).when(beanDefinition).type();
+        when(beanDefinition.name()).thenReturn(beanName);
+        when(beanDefinition.dependencies()).thenReturn(dependencies);
+        return beanDefinition;
+    }
+}

--- a/src/test/java/com/hoverla/bring/context/bean/initializer/BeanInitializerTest.java
+++ b/src/test/java/com/hoverla/bring/context/bean/initializer/BeanInitializerTest.java
@@ -1,0 +1,94 @@
+package com.hoverla.bring.context.bean.initializer;
+
+import com.hoverla.bring.context.bean.definition.BeanDefinition;
+import com.hoverla.bring.context.bean.definition.BeanDefinitionContainer;
+import com.hoverla.bring.context.bean.dependency.BeanDependency;
+import com.hoverla.bring.context.bean.dependency.BeanDependencyNameResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BeanInitializerTest {
+    private static final String BEAN_DEFINITION_1 = "beanDefinition1";
+    private static final String BEAN_DEFINITION_2 = "beanDefinition2";
+    private static final String BEAN_DEFINITION_3 = "beanDefinition3";
+    private static final String BEAN_DEFINITION_4 = "beanDefinition4";
+    private static final String BEAN_DEFINITION_5 = "beanDefinition5";
+
+    private BeanInitializer beanInitializer;
+    private BeanDependencyNameResolver nameResolver;
+
+    @BeforeEach
+    void setUp() {
+        nameResolver = mock(BeanDependencyNameResolver.class);
+        beanInitializer = new BeanInitializer(nameResolver);
+    }
+
+    @Test
+    @DisplayName("Initialization test. Verifies that 'instance' method of BeanDefinition is called with correct dependencies")
+    void testInitialize() {
+        BeanDefinition beanDefinition1 = getDefinition(BEAN_DEFINITION_1, BEAN_DEFINITION_2, BEAN_DEFINITION_3);
+        BeanDefinition beanDefinition2 = getDefinition(BEAN_DEFINITION_2, BEAN_DEFINITION_3, BEAN_DEFINITION_4);
+        BeanDefinition beanDefinition3 = getDefinition(BEAN_DEFINITION_3, BEAN_DEFINITION_4);
+        BeanDefinition beanDefinition4 = getDefinition(BEAN_DEFINITION_4);
+        BeanDefinition beanDefinition5 = getDefinition(BEAN_DEFINITION_5);
+
+
+        List<BeanDefinition> beans = List.of(beanDefinition1, beanDefinition2, beanDefinition3, beanDefinition4);
+        BeanDefinitionContainer container = new BeanDefinitionContainer(beans);
+
+        Map<BeanDefinition, BeanDefinition[]> expectedInvocationArgs = Map.of(
+            beanDefinition1, new BeanDefinition[]{beanDefinition2, beanDefinition3},
+            beanDefinition2, new BeanDefinition[]{beanDefinition3, beanDefinition4},
+            beanDefinition3, new BeanDefinition[]{beanDefinition4},
+            beanDefinition4, new BeanDefinition[0],
+            beanDefinition5, new BeanDefinition[0]
+        );
+
+        beanInitializer.initialize(container);
+
+        verify(nameResolver).resolveDependencyNames(container);
+
+        for (var beanDefinition : container.getBeanDefinitions()) {
+            ArgumentCaptor<BeanDefinition> beanDefinitionArgumentCaptor = ArgumentCaptor.forClass(BeanDefinition.class);
+
+            verify(beanDefinition, times(1)).instantiate(beanDefinitionArgumentCaptor.capture());
+
+            BeanDefinition[] expectedDependencies = expectedInvocationArgs.get(beanDefinition);
+            List<BeanDefinition> actualDependencies = beanDefinitionArgumentCaptor.getAllValues();
+
+            assertThat(actualDependencies).hasSize(expectedDependencies.length);
+            assertThat(actualDependencies).containsExactlyInAnyOrder(expectedDependencies);
+        }
+    }
+
+    private BeanDefinition getDefinition(String beanDefinitionName, String... dependencyNames) {
+        BeanDefinition beanDefinition = mock(BeanDefinition.class);
+        doReturn(BeanDefinition.class).when(beanDefinition).type();
+        when(beanDefinition.name()).thenReturn(beanDefinitionName);
+
+        Map<String, BeanDependency> dependencies = new HashMap<>();
+        for (var name : dependencyNames) {
+            dependencies.put(name, new BeanDependency(name, BeanDefinition.class));
+        }
+        when(beanDefinition.dependencies()).thenReturn(dependencies);
+        Supplier<?> instantiateAnswerSupplier = () -> when(beanDefinition.isInstantiated()).thenReturn(true);
+        doAnswer(ignore -> instantiateAnswerSupplier.get()).when(beanDefinition).instantiate(any());
+        return beanDefinition;
+    }
+}

--- a/src/test/java/com/hoverla/bring/context/bean/postprocessor/SetterAutowiringPostProcessorTest.java
+++ b/src/test/java/com/hoverla/bring/context/bean/postprocessor/SetterAutowiringPostProcessorTest.java
@@ -1,5 +1,11 @@
-package com.hoverla.bring.context;
+package com.hoverla.bring.context.bean.postprocessor;
 
+import com.hoverla.bring.context.AnnotationApplicationContextImpl;
+import com.hoverla.bring.context.ApplicationContext;
+import com.hoverla.bring.context.bean.definition.BeanDefinitionMapper;
+import com.hoverla.bring.context.bean.dependency.BeanDependencyNameResolver;
+import com.hoverla.bring.context.bean.initializer.BeanInitializer;
+import com.hoverla.bring.context.bean.scanner.BeanAnnotationScanner;
 import com.hoverla.bring.context.fixtures.setter.success.Container;
 import com.hoverla.bring.context.fixtures.setter.success.MessageServiceHolder;
 import com.hoverla.bring.context.fixtures.setter.success.ServiceWithIncorrectSetterName;
@@ -9,16 +15,20 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
 
-public class SetterAutowiringPostProcessorTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SetterAutowiringPostProcessorTest {
 
     @Test
     @Order(1)
     @DisplayName("Setter autowiring has been successful")
     void autowiringSetterWorksProperly() {
         ApplicationContext autowiringContext =
-                new AnnotationApplicationContextImpl("com.hoverla.bring.context.fixtures.setter.success");
+            getApplicationContext("com.hoverla.bring.context.fixtures.setter.success");
         MessageServiceHolder holder = autowiringContext.getBean(MessageServiceHolder.class);
         assertEquals("some text", holder.getMessageService().getMessage());
     }
@@ -28,7 +38,7 @@ public class SetterAutowiringPostProcessorTest {
     @DisplayName("Setter with 2 arguments has been successful")
     void autowiringSetterWith2ArgumentsWorksProperly() {
         ApplicationContext autowiringContext =
-                new AnnotationApplicationContextImpl("com.hoverla.bring.context.fixtures.setter.success");
+            getApplicationContext("com.hoverla.bring.context.fixtures.setter.success");
         Container container = autowiringContext.getBean(Container.class);
         assertEquals("some text", container.getMessageService().getMessage());
         assertEquals(2, container.getNumberService().getNumber());
@@ -39,7 +49,7 @@ public class SetterAutowiringPostProcessorTest {
     @DisplayName("Setter with private modified hasn't been successful")
     void autowiringSetterDoesntWorkForPrivateSetter() {
         ApplicationContext autowiringContext =
-                new AnnotationApplicationContextImpl("com.hoverla.bring.context.fixtures.setter.success");
+            getApplicationContext("com.hoverla.bring.context.fixtures.setter.success");
         ServiceWithPrivateSetter bean = autowiringContext.getBean(ServiceWithPrivateSetter.class);
         assertNull(bean.getMessageService());
     }
@@ -49,7 +59,7 @@ public class SetterAutowiringPostProcessorTest {
     @DisplayName("Setter with with incorrect name hasn't been successful")
     void autowiringSetterDoesntWorkForIncorrectSetterName() {
         ApplicationContext autowiringContext =
-                new AnnotationApplicationContextImpl("com.hoverla.bring.context.fixtures.setter.success");
+            getApplicationContext("com.hoverla.bring.context.fixtures.setter.success");
         ServiceWithIncorrectSetterName bean = autowiringContext.getBean(ServiceWithIncorrectSetterName.class);
         assertNull(bean.getMessageService());
     }
@@ -59,7 +69,13 @@ public class SetterAutowiringPostProcessorTest {
     @DisplayName("Setter throw invokeMethodException")
     void autowiringSetterThrowInvokeMethodException() {
         InvokeMethodException exception = assertThrows(InvokeMethodException.class, () ->
-                new AnnotationApplicationContextImpl("com.hoverla.bring.context.fixtures.setter.fail"));
+            getApplicationContext("com.hoverla.bring.context.fixtures.setter.fail"));
         assertEquals("Can't invoke 'setMessageService' method", exception.getMessage());
+    }
+
+    private ApplicationContext getApplicationContext(String packageToScan) {
+        return new AnnotationApplicationContextImpl(
+            List.of(new BeanAnnotationScanner(new BeanDefinitionMapper(), packageToScan)),
+            new BeanInitializer(new BeanDependencyNameResolver()));
     }
 }

--- a/src/test/java/com/hoverla/bring/context/bean/scanner/BeanAnnotationScannerTest.java
+++ b/src/test/java/com/hoverla/bring/context/bean/scanner/BeanAnnotationScannerTest.java
@@ -1,0 +1,71 @@
+package com.hoverla.bring.context.bean.scanner;
+
+import com.hoverla.bring.context.bean.definition.BeanDefinition;
+import com.hoverla.bring.context.bean.definition.BeanDefinitionMapper;
+import com.hoverla.bring.context.fixtures.bean.success.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BeanAnnotationScannerTest {
+
+    private static final String TEST_PACKAGE_TO_SCAN = "com.hoverla.bring.context.fixtures.bean.success";
+    private static final String INVALID_PACKAGE_TO_SCAN = "com.hoverla.bring.context.fixtures.bean.invalid";
+
+    @Mock
+    private BeanDefinitionMapper mapper;
+
+    @Test
+    @DisplayName("Scans all beans from a given package, validates those classes and maps them to bean definitions")
+    void testScan() {
+        Set<Class<?>> expectedBeanClasses = Set.of(A.class, B.class, ChildServiceBeanOne.class,
+            ChildServiceBeanTwo.class, TestBeanWithName.class, TestBeanWithoutName.class);
+        for (Class<?> beanClass : expectedBeanClasses) {
+            BeanDefinition beanDefinition = getBeanDefinition(beanClass);
+            when(mapper.mapToBeanDefinition(beanClass)).thenReturn(beanDefinition);
+        }
+
+        var beanAnnotationScanner = new BeanAnnotationScanner(mapper, TEST_PACKAGE_TO_SCAN);
+        List<BeanDefinition> resolvedDefinitions = beanAnnotationScanner.scan();
+
+        verify(mapper, times(expectedBeanClasses.size())).mapToBeanDefinition(any(Class.class));
+
+
+        assertEquals(expectedBeanClasses.size(), resolvedDefinitions.size());
+        assertTrue(resolvedDefinitions.stream().map(BeanDefinition::type).allMatch(expectedBeanClasses::contains));
+    }
+
+    @Test
+    @DisplayName("Scan returns empty collection, since there are no classes marked with @Bean. Validation and mapping don't happen")
+    void testScanWithoutBeans() {
+        var beanAnnotationScanner = new BeanAnnotationScanner(mapper, INVALID_PACKAGE_TO_SCAN);
+        List<BeanDefinition> scannedDefinitions = beanAnnotationScanner.scan();
+
+        verify(mapper, never()).mapToBeanDefinition(any(Class.class));
+
+        assertThat(scannedDefinitions).isEmpty();
+    }
+
+    private BeanDefinition getBeanDefinition(Class<?> beanClass) {
+        BeanDefinition beanDefinition = mock(BeanDefinition.class);
+        doReturn(beanClass).when(beanDefinition).type();
+        return beanDefinition;
+    }
+}

--- a/src/test/java/com/hoverla/bring/context/bean/scanner/BeanConfigurationScannerTest.java
+++ b/src/test/java/com/hoverla/bring/context/bean/scanner/BeanConfigurationScannerTest.java
@@ -1,0 +1,58 @@
+package com.hoverla.bring.context.bean.scanner;
+
+import com.hoverla.bring.context.bean.definition.BeanDefinition;
+import com.hoverla.bring.context.bean.definition.BeanDefinitionMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class BeanConfigurationScannerTest {
+
+    private static final String CONFIG_PACKAGE_NAME = "com.hoverla.bring.context.fixtures.config";
+    private static final String INVALID_PACKAGE_NAME = "com.hoverla.bring.context.fixtures.config.invalid";
+
+    @Mock
+    private BeanDefinitionMapper mapper;
+
+    private ConfigurationBeanScanner scanner;
+
+    @Test
+    @DisplayName("Successfully scans beans from @Configuration classes in specified packages")
+    void scansBeansFromConfigurationClasses() {
+        scanner = new ConfigurationBeanScanner(mapper, CONFIG_PACKAGE_NAME, INVALID_PACKAGE_NAME);
+        List<BeanDefinition> beanDefinitions = scanner.scan();
+        assertThat(beanDefinitions).hasSize(4);
+    }
+
+    @Test
+    @DisplayName("Returns empty list when @Configuration class is not found")
+    void returnsEmptyListIfConfigurationNotFound() {
+        scanner = new ConfigurationBeanScanner(mapper, INVALID_PACKAGE_NAME);
+
+        List<BeanDefinition> beanDefinitions = scanner.scan();
+
+        verify(mapper, never()).mapToBeanDefinition(any(), any());
+        assertThat(beanDefinitions).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Returns empty list when we don't pass any package to scan")
+    void returnsEmptyListIfThereIsNoPackageToScan() {
+        scanner = new ConfigurationBeanScanner(mapper);
+
+        List<BeanDefinition> beanDefinitions = scanner.scan();
+
+        verify(mapper, never()).mapToBeanDefinition(any(), any());
+        assertThat(beanDefinitions).isEmpty();
+    }
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/autowired/definition/success/BeanWithAutowiredConstructor.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/autowired/definition/success/BeanWithAutowiredConstructor.java
@@ -1,0 +1,21 @@
+package com.hoverla.bring.context.fixtures.autowired.definition.success;
+
+import com.hoverla.bring.annotation.Autowired;
+import com.hoverla.bring.annotation.Bean;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Bean
+public class BeanWithAutowiredConstructor {
+    @Getter
+    private final String string;
+    @Getter
+    private final LocalDate date;
+
+    @Autowired
+    public BeanWithAutowiredConstructor(String string, LocalDate date) {
+        this.string = string;
+        this.date = date;
+    }
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/autowired/definition/success/BeanWithCombinedAutowired.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/autowired/definition/success/BeanWithCombinedAutowired.java
@@ -1,0 +1,22 @@
+package com.hoverla.bring.context.fixtures.autowired.definition.success;
+
+import com.hoverla.bring.annotation.Autowired;
+import com.hoverla.bring.annotation.Bean;
+import lombok.Getter;
+
+@Bean
+public class BeanWithCombinedAutowired {
+
+    @Getter
+    private final BeanWithAutowiredConstructor beanWithAutowiredConstructor;
+
+    @Getter
+    @Autowired
+    private BeanWithConstructor beanWithConstructor;
+
+
+    @Autowired
+    public BeanWithCombinedAutowired(BeanWithAutowiredConstructor beanWithAutowiredConstructor) {
+        this.beanWithAutowiredConstructor = beanWithAutowiredConstructor;
+    }
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/autowired/definition/success/BeanWithConstructor.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/autowired/definition/success/BeanWithConstructor.java
@@ -1,0 +1,19 @@
+package com.hoverla.bring.context.fixtures.autowired.definition.success;
+
+import com.hoverla.bring.annotation.Bean;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Bean("someBean")
+public class BeanWithConstructor {
+    @Getter
+    private final String string;
+    @Getter
+    private final LocalDate date;
+
+    public BeanWithConstructor(String string, LocalDate date) {
+        this.string = string;
+        this.date = date;
+    }
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/autowired/definition/success/BeanWithMultipleAutowiredFields.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/autowired/definition/success/BeanWithMultipleAutowiredFields.java
@@ -1,0 +1,22 @@
+package com.hoverla.bring.context.fixtures.autowired.definition.success;
+
+import com.hoverla.bring.annotation.Autowired;
+import com.hoverla.bring.annotation.Bean;
+import com.hoverla.bring.context.fixtures.bean.success.TestBeanWithoutName;
+import lombok.Getter;
+
+@Bean
+public class BeanWithMultipleAutowiredFields {
+
+    @Autowired
+    @Getter
+    private TestBeanWithoutName testBeanWithoutName;
+
+    @Autowired
+    @Getter
+    String string;
+
+    @Autowired
+    @Getter
+    Double aDouble;
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/autowired/definition/success/BeanWithSetterAutowiring.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/autowired/definition/success/BeanWithSetterAutowiring.java
@@ -1,0 +1,17 @@
+package com.hoverla.bring.context.fixtures.autowired.definition.success;
+
+import com.hoverla.bring.annotation.Autowired;
+import com.hoverla.bring.annotation.Bean;
+
+@Bean
+public class BeanWithSetterAutowiring {
+
+    @Autowired
+    BeanWithAutowiredConstructor beanWithAutowiredConstructor;
+
+    @Autowired
+    BeanWithConstructor beanWithConstructor;
+
+    @Autowired
+    Double aDouble;
+}

--- a/src/test/java/com/hoverla/bring/context/fixtures/bean/primary/error/WolfError.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/bean/primary/error/WolfError.java
@@ -2,7 +2,6 @@ package com.hoverla.bring.context.fixtures.bean.primary.error;
 
 import com.hoverla.bring.annotation.Bean;
 import com.hoverla.bring.annotation.Primary;
-import com.hoverla.bring.context.fixtures.bean.success.A;
 
 @Bean
 @Primary

--- a/src/test/java/com/hoverla/bring/context/fixtures/bean/success/TestBeanWithoutName.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/bean/success/TestBeanWithoutName.java
@@ -1,7 +1,9 @@
 package com.hoverla.bring.context.fixtures.bean.success;
 
 import com.hoverla.bring.annotation.Bean;
+import lombok.EqualsAndHashCode;
 
 @Bean
+@EqualsAndHashCode
 public class TestBeanWithoutName {
 }

--- a/src/test/java/com/hoverla/bring/context/fixtures/config/TestConfiguration.java
+++ b/src/test/java/com/hoverla/bring/context/fixtures/config/TestConfiguration.java
@@ -1,0 +1,32 @@
+package com.hoverla.bring.context.fixtures.config;
+
+import com.hoverla.bring.annotation.Bean;
+import com.hoverla.bring.annotation.Configuration;
+
+@Configuration
+public class TestConfiguration {
+    @Bean
+    public String unnamedBean() {
+        return "string";
+    }
+
+    @Bean("stringBean")
+    public String namedBean() {
+        return "namedString";
+    }
+
+    @Bean
+    public Long beanWithDependencies(long n, String s) {
+        return n - Long.parseLong(s);
+    }
+
+    @Bean
+    public Long anotherBeanWithDependencies(long n, String s, String s1) {
+        return n - Long.parseLong(s) + Long.parseLong(s1);
+    }
+
+    public String notABean() {
+        return "I'm not a bean.";
+    }
+
+}


### PR DESCRIPTION
This PR adds the possibility to use the `@Configuration` classes. Also, it introduces the `BeanDefinition`, `BeanDependency`, and `BeanScanner` support. Currently, we support only Configuration and Default (beans marked with a `@Bean` annotation) bean definitions. Also, there is an improvement for the `@Autowired` annotation. It supports constructor autowiring now. And of course, some unit tests were added